### PR TITLE
financial class VS and CS

### DIFF
--- a/input/fsh/VRCL/aliases.fsh
+++ b/input/fsh/VRCL/aliases.fsh
@@ -10,6 +10,7 @@ Alias: $v3-Ethnicity = http://terminology.hl7.org/CodeSystem/v3-Ethnicity
 Alias: $v2-0203 = http://terminology.hl7.org/CodeSystem/v2-0203
 Alias: $v2-0532 = http://terminology.hl7.org/CodeSystem/v2-0532
 Alias: $CodeSystem-local-component-codes = CodesystemLocalComponentCodes 
+Alias: $CodeSystem-birth-and-fetal-death-financial-class = CodesystemLocalComponentCodes 
 
 Alias: $Extension-partial-date-time = ExtensionPartialDateTimeVitalRecords //// http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-partial-date-time
 Alias: $Extension-date-year = ExtensionDateYearVitalRecords // http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-date-year

--- a/input/fsh/VRCL/codesystems/CodeSystemBirthAndFetalDeathFinancialClass.fsh
+++ b/input/fsh/VRCL/codesystems/CodeSystemBirthAndFetalDeathFinancialClass.fsh
@@ -1,0 +1,15 @@
+CodeSystem: BirthAndFetalDeathFinancialClassCS
+Id: CodeSystem-vr-birth-and-fetal-death-financial-class
+Title: "CodeSystem - Birth and Death Financial Class"
+Description: "This code system contains codes local codes from PHINVADs Source of Payment Typology (PHDSC) valueset"
+* ^caseSensitive = true
+* ^content = #complete
+* ^experimental = false
+* #indianhealth "Indian Health Service or Tribe" //33
+* #medicaid "MEDICAID" //2
+* #nosource "No Typology Code available for payment source" //99
+* #othergov "Other Government (Federal, State, Local not specified)" //38
+* #privateinsurance "PRIVATE HEALTH INSURANCE" //5
+* #selfpay "Self-pay" //81
+* #tricare "TRICARE (CHAMPUS)" //311
+* #unkown "Unavailable / Unknown" //9999

--- a/input/fsh/VRCL/conceptmaps/CM_BirthAndFetalDeathFinancialClass.fsh
+++ b/input/fsh/VRCL/conceptmaps/CM_BirthAndFetalDeathFinancialClass.fsh
@@ -1,0 +1,14 @@
+Instance: BirthAndFetalDeathFinancialClassCM
+InstanceOf: ConceptMap
+Usage: #definition
+* experimental = false
+* insert ConceptMapIntro(BirthAndFetalDeathFinancialClass, ValueSetBirthAndFetalDeathFinancialClass)
+* insert AddGroup("IJE", $CodeSystem-birth-and-fetal-death-financial-class)
+* insert MapConcept( #1,  "Medicaid", #medicaid, "MEDICAID")
+* insert MapConcept( #2,  "Private Insurance", #privateinsurance, "PRIVATE HEALTH INSURANCE")
+* insert MapConcept( #3,  "Self-pay", #selfpay, "Self-pay" )
+* insert MapConcept( #4,  "Indian Health Service", #indianhealth, "Indian Health Service or Tribe")
+* insert MapConcept( #5,  "CHAMPUS/TRICARE", #tricare, "TRICARE (CHAMPUS\)")
+* insert MapConcept( #6,  "Other Government (Fed\, State\, Local\)", #othergov, "Other Government (Federal\, State\, Local not specified\)" )
+* insert MapConcept( #8,  "Other", #nosource, "No Typology Code available for payment source")
+* insert MapConcept( #9,  "Unknown", #unkown, "Unavailable / Unknown" //9999" )

--- a/input/fsh/VRCL/valuesets-phinvads/ValueSetBirthAndFetalDeathFinancialClass.fsh
+++ b/input/fsh/VRCL/valuesets-phinvads/ValueSetBirthAndFetalDeathFinancialClass.fsh
@@ -1,0 +1,14 @@
+ValueSet: ValueSetBirthAndFetalDeathFinancialClass
+Id: ValueSet-birth-and-fetal-death-financial-class
+Title: "ValueSet - Birth and Fetal Death Financial Class"
+Description: "This value set contains codes to represent birth and fetal death financial class (based on PHVS_BirthAndFetalDeathFinancialClass_NCHS)."
+* ^experimental = false
+* ^copyright = "include appropriate copyright ruleset"
+* BirthAndFetalDeathFinancialClassCS#indianhealth "Indian Health Service or Tribe" //33
+* BirthAndFetalDeathFinancialClassCS#medicaid "MEDICAID" //2
+* BirthAndFetalDeathFinancialClassCS#nosource "No Typology Code available for payment source" //99
+* BirthAndFetalDeathFinancialClassCS#othergov "Other Government (Federal, State, Local not specified)" //38
+* BirthAndFetalDeathFinancialClassCS#privateinsurance "PRIVATE HEALTH INSURANCE" //5
+* BirthAndFetalDeathFinancialClassCS#selfpay "Self-pay" //81
+* BirthAndFetalDeathFinancialClassCS#tricare "TRICARE (CHAMPUS)" //311
+* BirthAndFetalDeathFinancialClassCS#unkown "Unavailable / Unknown" //9999

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -173,6 +173,7 @@ groups:
     resources:
       - ValueSetFetalDeathCauseOrCondition
       - ValueSetHistologicalPlacentalExamination
+      - ValueSetBirthAndFetalDeathFinancialClass
 
   VRCLValueSets:
     name: VRCL ValueSets


### PR DESCRIPTION
## Changes 
Added Code System and Value System for "BirthAndFetalDeathFinancialClass"

**note:** did not include concept map because of IJE - VS mismatch. All values matched except IJE had an "other" while PHINVADS included no other but a "No Typology Code available for payment source" which IJE lacked. A concept map was created with the matching one codes but not included (based on email exchange on 1-1 mappings needed).