### PR TITLE
updated content transitions

### DIFF
--- a/FHIR-us-vrsandbox.xml
+++ b/FHIR-us-vrsandbox.xml
@@ -23,23 +23,13 @@
 <artifact id="StructureDefinition/AuxiliaryStateIdentifier1" key="StructureDefinition-AuxiliaryStateIdentifier1" name="Auxiliary State Identifier1"/>
 <artifact id="StructureDefinition/AuxiliaryStateIdentifier2" key="StructureDefinition-AuxiliaryStateIdentifier2" name="Auxiliary State Identifier2"/>
 <artifact id="StructureDefinition/vrdr-birth-record-identifier" key="StructureDefinition-vrdr-birth-record-identifier" name="Birth Record Identifier"/>
-<artifact id="ConceptMap/BirthAndFetalDeathFinancialClassCM" key="ConceptMap-BirthAndFetalDeathFinancialClassCM" name="BirthAndFetalDeathFinancialClass Concept Map"/>
-<artifact id="ConceptMap/BirthAttendantTitlesCM" key="ConceptMap-BirthAttendantTitlesCM" name="BirthAttendantTitles Concept Map"/>
-<artifact id="ConceptMap/BirthDeliveryOccurredCM" key="ConceptMap-BirthDeliveryOccurredCM" name="BirthDeliveryOccurred Concept Map"/>
 <artifact id="Observation/BirthRecordIdentifier-Example1" key="Observation-BirthRecordIdentifier-Example1" name="BirthRecordIdentifier-Example1"/>
 <artifact id="Observation/BirthRecordIdentifierUT-Example1" key="Observation-BirthRecordIdentifierUT-Example1" name="BirthRecordIdentifierUT-Example1"/>
-<artifact id="StructureDefinition/vr-demographic-coded-bundle" key="StructureDefinition-vr-demographic-coded-bundle" name="Bundle - Demographic Coded Content Bundle for BFDR"/>
-<artifact id="StructureDefinition/BundleDocumentBFDR" key="StructureDefinition-BundleDocumentBFDR" name="Bundle - Document Birth and Fetal Death"/>
 <artifact id="StructureDefinition/Bundle-document-mdi-to-edrs" key="StructureDefinition-Bundle-document-mdi-to-edrs" name="Bundle - Document MDI to EDRS"/>
-<artifact id="Bundle/bundle-jurisdiction-fetal-death-not-named" key="Bundle-bundle-jurisdiction-fetal-death-not-named" name="Bundle - Jurisdiction Fetal Death Report - Fetus Not Named"/>
-<artifact id="Bundle/bundle-jurisdiction-live-birth-babyg-quinn" key="Bundle-bundle-jurisdiction-live-birth-babyg-quinn" name="Bundle - Jurisdiction Live Birth Report - Baby G Quinn"/>
 <artifact id="Bundle/bundle-mdi-to-edrs-a-freeman" key="Bundle-bundle-mdi-to-edrs-a-freeman" name="Bundle - MDI to EDRS - Freeman"/>
 <artifact id="StructureDefinition/Bundle-message-tox-to-mdi" key="StructureDefinition-Bundle-message-tox-to-mdi" name="Bundle - Message Toxicology to MDI"/>
 <artifact id="Bundle/bundle-mdi-tox-report-message-a-freeman" key="Bundle-bundle-mdi-tox-report-message-a-freeman" name="Bundle - Message Toxicology to MDI - Freeman"/>
-<artifact id="Bundle/bundle-provider-fetal-death-not-named" key="Bundle-bundle-provider-fetal-death-not-named" name="Bundle - Provider Fetal Death Report - Fetus Not Named"/>
-<artifact id="Bundle/bundle-provider-live-birth-babyg-quinn" key="Bundle-bundle-provider-live-birth-babyg-quinn" name="Bundle - Provider Live Birth - Baby G Quinn"/>
 <artifact id="CodeSystem/vrdr-bypass-edit-flag-cs" key="CodeSystem-vrdr-bypass-edit-flag-cs" name="Bypass Edit Flag Code System"/>
-<artifact id="CapabilityStatement/CapabilityStatement-bfdr" key="CapabilityStatement-CapabilityStatement-bfdr" name="CapabilityStatement - Birth and Fetal Death"/>
 <artifact id="CapabilityStatement/CapabilityStatement-edrs-server" key="CapabilityStatement-CapabilityStatement-edrs-server" name="CapabilityStatement - Electronic Death Reporting System (EDRS) Server"/>
 <artifact id="CapabilityStatement/CapabilityStatement-forensic-toxicology-laboratory-server" key="CapabilityStatement-CapabilityStatement-forensic-toxicology-laboratory-server" name="CapabilityStatement - Forensic Toxicology Laboratory Server"/>
 <artifact id="CapabilityStatement/CapabilityStatement-medical-examiner-coroner-server" key="CapabilityStatement-CapabilityStatement-medical-examiner-coroner-server" name="CapabilityStatement - Medical Examiner/Coroner Server"/>
@@ -56,82 +46,14 @@
 <artifact id="ValueSet/vrdr-certifier-types-vs" key="ValueSet-vrdr-certifier-types-vs" name="Certifier Types VS"/>
 <artifact id="Practitioner/Certifier-Example1" key="Practitioner-Certifier-Example1" name="Certifier-Example1"/>
 <artifact id="ConceptMap/CertifierTypesCM" key="ConceptMap-CertifierTypesCM" name="CertifierTypes Concept Map"/>
-<artifact id="CodeSystem/CodeSystem-abnormal-conditions-newborn" key="CodeSystem-CodeSystem-abnormal-conditions-newborn" name="CodeSystem - Abnormal Conditions Newborn"/>
-<artifact id="CodeSystem/CodeSystem-vr-birth-delivery-occurred" key="CodeSystem-CodeSystem-vr-birth-delivery-occurred" name="CodeSystem - Birth Delivery Occurred"/>
-<artifact id="CodeSystem/CodeSystem-vr-edit-flags" key="CodeSystem-CodeSystem-vr-edit-flags" name="CodeSystem - Birth and Death Edit Flags Vital Records"/>
-<artifact id="CodeSystem/CodeSystem-vr-birth-and-fetal-death-financial-class" key="CodeSystem-CodeSystem-vr-birth-and-fetal-death-financial-class" name="CodeSystem - Birth and Death Financial Class"/>
-<artifact id="CodeSystem/CodeSystem-canadian-provinces-vr" key="CodeSystem-CodeSystem-canadian-provinces-vr" name="CodeSystem - Canadian Provinces Vital Records"/>
-<artifact id="CodeSystem/CodeSystem-country-code-vr" key="CodeSystem-CodeSystem-country-code-vr" name="CodeSystem - Country Codes Vital Records"/>
 <artifact id="CodeSystem/CodeSystem-death-pregnancy-status" key="CodeSystem-CodeSystem-death-pregnancy-status" name="CodeSystem - Death Pregnancy Status Vital Records"/>
-<artifact id="CodeSystem/CodeSystem-vr-fetal-death-cause-or-condition" key="CodeSystem-CodeSystem-vr-fetal-death-cause-or-condition" name="CodeSystem - Fetal Death Cause or Condition"/>
-<artifact id="CodeSystem/CodeSystem-hispanic-origin-vr" key="CodeSystem-CodeSystem-hispanic-origin-vr" name="CodeSystem - HispanicOrigin Vital Records"/>
-<artifact id="CodeSystem/CodeSystem-informant-relationship-to-mother" key="CodeSystem-CodeSystem-informant-relationship-to-mother" name="CodeSystem - Informant Relationship to Mother"/>
-<artifact id="CodeSystem/CodeSystem-jurisdictions-vr" key="CodeSystem-CodeSystem-jurisdictions-vr" name="CodeSystem - Jurisdictions Vital Records"/>
-<artifact id="CodeSystem/CodeSystem-local-observation-codes-vr" key="CodeSystem-CodeSystem-local-observation-codes-vr" name="CodeSystem - Local Observation Codes Vital Records"/>
 <artifact id="CodeSystem/CodeSystem-vr-codes" key="CodeSystem-CodeSystem-vr-codes" name="CodeSystem - MDI"/>
-<artifact id="CodeSystem/CodeSystem-missing-value-reason-vr" key="CodeSystem-CodeSystem-missing-value-reason-vr" name="CodeSystem - Missing Value Reason Vital Records"/>
-<artifact id="CodeSystem/CodeSystem-race-code-vr" key="CodeSystem-CodeSystem-race-code-vr" name="CodeSystem - Race Code Vital Records"/>
-<artifact id="CodeSystem/CodeSystem-race-recode-40-vr" key="CodeSystem-CodeSystem-race-recode-40-vr" name="CodeSystem - Race Recode 40 Vital Records"/>
 <artifact id="Observation/CodedRaceAndEthnicity-Example1" key="Observation-CodedRaceAndEthnicity-Example1" name="CodedRaceAndEthnicity-Example1"/>
 <artifact id="StructureDefinition/vrdr-coding-status-values" key="StructureDefinition-vrdr-coding-status-values" name="Coding Status Values"/>
 <artifact id="Parameters/CodingStatusValues-Example1" key="Parameters-CodingStatusValues-Example1" name="CodingStatusValues-Example1"/>
-<artifact id="StructureDefinition/CompositionCodedCauseOfFetalDeath" key="StructureDefinition-CompositionCodedCauseOfFetalDeath" name="Composition - Coded Cause of Fetal Death"/>
-<artifact id="Composition/composition-coded-cause-of-fetal-death-not-named" key="Composition-composition-coded-cause-of-fetal-death-not-named" name="Composition - Coded Cause of Fetal Death - Fetus Not Named"/>
-<artifact id="StructureDefinition/Composition-coded-race-and-ethnicity" key="StructureDefinition-Composition-coded-race-and-ethnicity" name="Composition - Coded Race and Ethnicity"/>
-<artifact id="StructureDefinition/CompositionJurisdictionFetalDeathReport" key="StructureDefinition-CompositionJurisdictionFetalDeathReport" name="Composition - Jurisdiction Fetal Death Report"/>
-<artifact id="Composition/composition-jurisdiction-fetal-death-not-named" key="Composition-composition-jurisdiction-fetal-death-not-named" name="Composition - Jurisdiction Fetal Death Report - Fetus Not Named"/>
-<artifact id="StructureDefinition/CompositionJurisdictionLiveBirthReport" key="StructureDefinition-CompositionJurisdictionLiveBirthReport" name="Composition - Jurisdiction Live Birth Report"/>
-<artifact id="Composition/composition-jurisdiction-live-birth-babyg-quinn" key="Composition-composition-jurisdiction-live-birth-babyg-quinn" name="Composition - Jurisdiction Live Birth Report - BabyG Quinn"/>
 <artifact id="StructureDefinition/Composition-mdi-to-edrs" key="StructureDefinition-Composition-mdi-to-edrs" name="Composition - MDI to EDRS"/>
-<artifact id="StructureDefinition/CompositionProviderFetalDeathReport" key="StructureDefinition-CompositionProviderFetalDeathReport" name="Composition - Provider Fetal Death Report"/>
-<artifact id="Composition/composition-provider-fetal-death-not-named" key="Composition-composition-provider-fetal-death-not-named" name="Composition - Provider Fetal Death Report - Fetus Not Named"/>
-<artifact id="StructureDefinition/CompositionProviderLiveBirthReport" key="StructureDefinition-CompositionProviderLiveBirthReport" name="Composition - Provider Live Birth Report"/>
-<artifact id="Composition/composition-provider-live-birth-babyg-quinn" key="Composition-composition-provider-live-birth-babyg-quinn" name="Composition - Provider Live Birth Report - BabyG Quinn"/>
-<artifact id="ConceptMap/ConceptMapBirthSexChildVitalRecords" key="ConceptMap-ConceptMapBirthSexChildVitalRecords" name="ConceptMap - Birth Sex Child Vital Records"/>
-<artifact id="ConceptMap/ConceptMapBirthSexFetusVitalRecords" key="ConceptMap-ConceptMapBirthSexFetusVitalRecords" name="ConceptMap - Birth Sex Fetus Vital Records"/>
-<artifact id="ConceptMap/ConceptMapEducationLevelVitalRecords" key="ConceptMap-ConceptMapEducationLevelVitalRecords" name="ConceptMap - Education Level Vital Records"/>
-<artifact id="ConceptMap/ConceptMapHispanicNoUnknownVitalRecords" key="ConceptMap-ConceptMapHispanicNoUnknownVitalRecords" name="ConceptMap - Hispanic No Unknown Vital Records"/>
-<artifact id="ConceptMap/ConceptMapHispanicOriginVitalRecords" key="ConceptMap-ConceptMapHispanicOriginVitalRecords" name="ConceptMap - Hispanic Origin Vital Records"/>
-<artifact id="ConceptMap/ConceptMapRaceCodeVitalRecords" key="ConceptMap-ConceptMapRaceCodeVitalRecords" name="ConceptMap - Race Code Vital Records"/>
-<artifact id="ConceptMap/ConceptMapRaceMissingValueReasonVitalRecords" key="ConceptMap-ConceptMapRaceMissingValueReasonVitalRecords" name="ConceptMap - Race Missing Value Reason Vital Records"/>
-<artifact id="ConceptMap/ConceptMapRaceRecode40VitalRecords" key="ConceptMap-ConceptMapRaceRecode40VitalRecords" name="ConceptMap - Race Recode40 Vital Records"/>
-<artifact id="ConceptMap/ConceptMapUnitsOfAgeVitalRecords" key="ConceptMap-ConceptMapUnitsOfAgeVitalRecords" name="ConceptMap - Units Of Age Vital Records"/>
-<artifact id="ConceptMap/ConceptMapYesNoNotApplicableVitalRecords" key="ConceptMap-ConceptMapYesNoNotApplicableVitalRecords" name="ConceptMap - Yes No Not Applicable Vital Records"/>
-<artifact id="ConceptMap/ConceptMapYesNoUnknownNotApplicableVitalRecords" key="ConceptMap-ConceptMapYesNoUnknownNotApplicableVitalRecords" name="ConceptMap - Yes No Unknown Not Applicable Vital Records"/>
-<artifact id="ConceptMap/ConceptMapYesNoUnknownVitalRecords" key="ConceptMap-ConceptMapYesNoUnknownVitalRecords" name="ConceptMap - Yes No Unknown Vital Records"/>
-<artifact id="StructureDefinition/Condition-chorioamnionitis" key="StructureDefinition-Condition-chorioamnionitis" name="Condition - Chorioamnionitis"/>
-<artifact id="Condition/condition-chorioamnionitis-jada-ann-quinn" key="Condition-condition-chorioamnionitis-jada-ann-quinn" name="Condition - Chorioamnionitis - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Condition-congenital-anomaly-of-newborn" key="StructureDefinition-Condition-congenital-anomaly-of-newborn" name="Condition - Congenital Anomaly of Newborn"/>
-<artifact id="Condition/condition-congenital-anomaly-of-newborn-babyg-quinn-2" key="Condition-condition-congenital-anomaly-of-newborn-babyg-quinn-2" name="Condition - Congenital Anomaly of Newborn - Baby G Quinn"/>
-<artifact id="Condition/condition-congenital-anomaly-of-newborn-babyg-quinn" key="Condition-condition-congenital-anomaly-of-newborn-babyg-quinn" name="Condition - Congenital Anomaly of Newborn - BabyG Quinn"/>
-<artifact id="StructureDefinition/Condition-eclampsia-hypertension" key="StructureDefinition-Condition-eclampsia-hypertension" name="Condition - Eclampsia Hypertension"/>
-<artifact id="Condition/condition-eclampsia-hypertension-jada-ann-quinn" key="Condition-condition-eclampsia-hypertension-jada-ann-quinn" name="Condition - Eclampsia Hypertension - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Condition-fetal-death-cause-or-condition" key="StructureDefinition-Condition-fetal-death-cause-or-condition" name="Condition - Fetal Death Cause or Condition"/>
-<artifact id="Condition/condition-fetal-death-cause-or-condition-not-named" key="Condition-condition-fetal-death-cause-or-condition-not-named" name="Condition - Fetal Death Cause or Condition - Fetus Not Named"/>
-<artifact id="StructureDefinition/Condition-fetal-death-other-cause-or-condition" key="StructureDefinition-Condition-fetal-death-other-cause-or-condition" name="Condition - Fetal Death Other Cause or Condition"/>
-<artifact id="Condition/condition-fetal-death-other-significant-cause-not-named" key="Condition-condition-fetal-death-other-significant-cause-not-named" name="Condition - Fetal Death Other Cause or Condition - Fetus Not Named"/>
-<artifact id="StructureDefinition/Condition-gestational-diabetes" key="StructureDefinition-Condition-gestational-diabetes" name="Condition - Gestational Diabetes"/>
-<artifact id="Condition/condition-gestational-diabetes-carmen-teresa-lee" key="Condition-condition-gestational-diabetes-carmen-teresa-lee" name="Condition - Gestational Diabetes - Carmen Teresa Lee"/>
-<artifact id="Condition/condition-gestational-diabetes-jada-ann-quinn" key="Condition-condition-gestational-diabetes-jada-ann-quinn" name="Condition - Gestational Diabetes - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Condition-gestational-hypertension" key="StructureDefinition-Condition-gestational-hypertension" name="Condition - Gestational Hypertension"/>
-<artifact id="Condition/condition-gestational-hypertension-jada-ann-quinn" key="Condition-condition-gestational-hypertension-jada-ann-quinn" name="Condition - Gestational Hypertension - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Condition-infection-present-during-pregnancy" key="StructureDefinition-Condition-infection-present-during-pregnancy" name="Condition - Infection Present During Pregnancy"/>
-<artifact id="Condition/condition-infection-present-during-pregnancy-jada-ann-quinn" key="Condition-condition-infection-present-during-pregnancy-jada-ann-quinn" name="Condition - Infection Present During Pregnancy - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Condition-perineal-laceration" key="StructureDefinition-Condition-perineal-laceration" name="Condition - Perineal Laceration"/>
-<artifact id="Condition/condition-perineal-laceration-jada-ann-quinn" key="Condition-condition-perineal-laceration-jada-ann-quinn" name="Condition - Perineal Laceration - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Condition-prepregnancy-diabetes" key="StructureDefinition-Condition-prepregnancy-diabetes" name="Condition - Prepregnancy Diabetes"/>
-<artifact id="Condition/condition-prepregnancy-diabetes-jada-ann-quinn" key="Condition-condition-prepregnancy-diabetes-jada-ann-quinn" name="Condition - Prepregnancy Diabetes - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Condition-prepregnancy-hypertension" key="StructureDefinition-Condition-prepregnancy-hypertension" name="Condition - Prepregnancy Hypertension"/>
-<artifact id="Condition/condition-prepregnancy-hypertension-carmen-teresa-lee" key="Condition-condition-prepregnancy-hypertension-carmen-teresa-lee" name="Condition - Prepregnancy Hypertension - Carmen Teresa Lee"/>
-<artifact id="Condition/condition-prepregnancy-hypertension-jada-ann-quinn" key="Condition-condition-prepregnancy-hypertension-jada-ann-quinn" name="Condition - Prepregnancy Hypertension - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Condition-ruptured-uterus" key="StructureDefinition-Condition-ruptured-uterus" name="Condition - Ruptured Uterus"/>
-<artifact id="Condition/condition-ruptured-uterus-jada-ann-quinn" key="Condition-condition-ruptured-uterus-jada-ann-quinn" name="Condition - Ruptured Uterus - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Condition-seizure" key="StructureDefinition-Condition-seizure" name="Condition - Seizure"/>
-<artifact id="Condition/condition-seizure-babyg-quinn" key="Condition-condition-seizure-babyg-quinn" name="Condition - Seizure - BabyG Quinn"/>
 <artifact id="ValueSet/vrdr-contributory-tobacco-use-vs" key="ValueSet-vrdr-contributory-tobacco-use-vs" name="Contributory Tobacco Use VS"/>
 <artifact id="ConceptMap/ContributoryTobaccoUseCM" key="ConceptMap-ContributoryTobaccoUseCM" name="ContributoryTobaccoUse Concept Map"/>
-<artifact id="StructureDefinition/Coverage-principal-payer-delivery" key="StructureDefinition-Coverage-principal-payer-delivery" name="Coverage - Principal Payer for Delivery"/>
-<artifact id="Coverage/coverage-principal-payer-for-delivery-jada-ann-quinn" key="Coverage-coverage-principal-payer-for-delivery-jada-ann-quinn" name="Coverage - Principal Payer for Delivery - Jada Ann Quinn"/>
 <artifact id="CodeSystem/vrdr-date-of-death-determination-methods-cs" key="CodeSystem-vrdr-date-of-death-determination-methods-cs" name="Date of Death Determination Methods"/>
 <artifact id="ValueSet/vrdr-date-of-death-determination-methods-vs" key="ValueSet-vrdr-date-of-death-determination-methods-vs" name="Date of Death Determination Methods Value Set"/>
 <artifact id="StructureDefinition/vrdr-death-certificate" key="StructureDefinition-vrdr-death-certificate" name="Death Certificate"/>
@@ -158,7 +80,6 @@
 <artifact id="StructureDefinition/vrdr-decedent-military-service" key="StructureDefinition-vrdr-decedent-military-service" name="Decedent Military Service"/>
 <artifact id="StructureDefinition/vrdr-decedent-mother" key="StructureDefinition-vrdr-decedent-mother" name="Decedent Mother"/>
 <artifact id="StructureDefinition/vrdr-decedent-spouse" key="StructureDefinition-vrdr-decedent-spouse" name="Decedent Spouse"/>
-<artifact id="StructureDefinition/vrdr-decedent-usual-work" key="StructureDefinition-vrdr-decedent-usual-work" name="Decedent Usual Work"/>
 <artifact id="Patient/Decedent-Example1" key="Patient-Decedent-Example1" name="Decedent-Example1"/>
 <artifact id="Patient/Decedent-Example2" key="Patient-Decedent-Example2" name="Decedent-Example2"/>
 <artifact id="Patient/Decedent-Example3" key="Patient-Decedent-Example3" name="Decedent-Example3"/>
@@ -173,7 +94,6 @@
 <artifact id="Patient/DecedentUT-Example1" key="Patient-DecedentUT-Example1" name="DecedentUT-Example1"/>
 <artifact id="Observation/DecedentUsualWork-Example1" key="Observation-DecedentUsualWork-Example1" name="DecedentUsualWork-Example1"/>
 <artifact id="Observation/DecedentUsualWork-Example2" key="Observation-DecedentUsualWork-Example2" name="DecedentUsualWork-Example2"/>
-<artifact id="ConceptMap/DeliveryRoutesCM" key="ConceptMap-DeliveryRoutesCM" name="DeliveryRoutes Concept Map"/>
 <artifact id="StructureDefinition/vrdr-demographic-coded-bundle" key="StructureDefinition-vrdr-demographic-coded-bundle" name="Demographic Coded Content Bundle"/>
 <artifact id="Bundle/DemographicCodedContentBundle-Example1" key="Bundle-DemographicCodedContentBundle-Example1" name="DemographicCodedContentBundle-Example1"/>
 <artifact id="StructureDefinition/DiagnosticReport-toxicology-to-mdi" key="StructureDefinition-DiagnosticReport-toxicology-to-mdi" name="DiagnosticReport - Toxicology Lab Result to MDI"/>
@@ -185,20 +105,13 @@
 <artifact id="CodeSystem/vrdr-document-section-cs" key="CodeSystem-vrdr-document-section-cs" name="Document Section Code System"/>
 <artifact id="ValueSet/vrdr-edit-bypass-01-vs" key="ValueSet-vrdr-edit-bypass-01-vs" name="Edit Bypass 01"/>
 <artifact id="ValueSet/vrdr-edit-bypass-012-vs" key="ValueSet-vrdr-edit-bypass-012-vs" name="Edit Bypass 012"/>
-<artifact id="ValueSet/vrdr-edit-bypass-01234-vs" key="ValueSet-vrdr-edit-bypass-01234-vs" name="Edit Bypass 01234"/>
 <artifact id="ValueSet/vrdr-edit-bypass-0124-vs" key="ValueSet-vrdr-edit-bypass-0124-vs" name="Edit Bypass 0124"/>
 <artifact id="ConceptMap/EditBypass01CM" key="ConceptMap-EditBypass01CM" name="EditBypass01 Concept Map"/>
 <artifact id="ConceptMap/EditBypass012CM" key="ConceptMap-EditBypass012CM" name="EditBypass012 Concept Map"/>
-<artifact id="ConceptMap/EditBypass01234CM" key="ConceptMap-EditBypass01234CM" name="EditBypass01234 Concept Map"/>
 <artifact id="ConceptMap/EditBypass0124CM" key="ConceptMap-EditBypass0124CM" name="EditBypass0124 Concept Map"/>
 <artifact id="Observation/EducationUT-Example1" key="Observation-EducationUT-Example1" name="EducationUT-Example1"/>
 <artifact id="Observation/EmergingIssues-Example1" key="Observation-EmergingIssues-Example1" name="EmergingIssues-Example1"/>
 <artifact id="Observation/EmergingIssuesUT-Example1" key="Observation-EmergingIssuesUT-Example1" name="EmergingIssuesUT-Example1"/>
-<artifact id="StructureDefinition/Encounter-birth" key="StructureDefinition-Encounter-birth" name="Encounter - Birth"/>
-<artifact id="Encounter/encounter-birth-babyg-quinn" key="Encounter-encounter-birth-babyg-quinn" name="Encounter - Birth - Baby G Quinn"/>
-<artifact id="StructureDefinition/Encounter-maternity" key="StructureDefinition-Encounter-maternity" name="Encounter - Maternity"/>
-<artifact id="Encounter/encounter-maternity-carmen-teresa-lee" key="Encounter-encounter-maternity-carmen-teresa-lee" name="Encounter - Maternity - Carmen Teresa Lee"/>
-<artifact id="Encounter/encounter-maternity-jada-ann-quinn" key="Encounter-encounter-maternity-jada-ann-quinn" name="Encounter - Maternity - Jada Ann Quinn"/>
 <artifact id="StructureDefinition/vrdr-entity-axis-cause-of-death" key="StructureDefinition-vrdr-entity-axis-cause-of-death" name="Entity Axis Cause Of Death"/>
 <artifact id="Observation/EntityAxisCauseOfDeath-Example1" key="Observation-EntityAxisCauseOfDeath-Example1" name="EntityAxisCauseOfDeath-Example1"/>
 <artifact id="Observation/EntityAxisCauseOfDeath-Example2" key="Observation-EntityAxisCauseOfDeath-Example2" name="EntityAxisCauseOfDeath-Example2"/>
@@ -207,33 +120,8 @@
 <artifact id="StructureDefinition/vrdr-examiner-contacted" key="StructureDefinition-vrdr-examiner-contacted" name="Examiner Contacted"/>
 <artifact id="Observation/ExaminerContacted-Example1" key="Observation-ExaminerContacted-Example1" name="ExaminerContacted-Example1"/>
 <artifact id="Observation/ExaminerContactedUT-Example1" key="Observation-ExaminerContactedUT-Example1" name="ExaminerContactedUT-Example1"/>
-<artifact id="StructureDefinition/BypassEditFlag" key="StructureDefinition-BypassEditFlag" name="Extension - BypassEditFlag Vital Records"/>
-<artifact id="StructureDefinition/CityCode" key="StructureDefinition-CityCode" name="Extension - City Code Vital Records"/>
-<artifact id="StructureDefinition/Extension-date-filed-by-registrar" key="StructureDefinition-Extension-date-filed-by-registrar" name="Extension - Date Filed by Registrar"/>
-<artifact id="StructureDefinition/Extension-date-received-by-registrar" key="StructureDefinition-Extension-date-received-by-registrar" name="Extension - Date received by Registrar"/>
-<artifact id="StructureDefinition/DistrictCode" key="StructureDefinition-DistrictCode" name="Extension - District Code Vital Records"/>
-<artifact id="StructureDefinition/Extension-encounter-maternity-reference" key="StructureDefinition-Extension-encounter-maternity-reference" name="Extension - Encounter Maternity Reference"/>
-<artifact id="StructureDefinition/Extension-fetal-death-local-file-number" key="StructureDefinition-Extension-fetal-death-local-file-number" name="Extension - Fetal Death Local File Number"/>
-<artifact id="StructureDefinition/Extension-fetal-death-report-number" key="StructureDefinition-Extension-fetal-death-report-number" name="Extension - Fetal Death Report Number"/>
-<artifact id="StructureDefinition/Extension-live-birth-certificate-number" key="StructureDefinition-Extension-live-birth-certificate-number" name="Extension - Live Birth Certificate Number"/>
-<artifact id="StructureDefinition/Extension-live-birth-local-file-number" key="StructureDefinition-Extension-live-birth-local-file-number" name="Extension - Live Birth Local File Number"/>
-<artifact id="StructureDefinition/ExtensionDatePartAbsentReasonVitalRecords" key="StructureDefinition-ExtensionDatePartAbsentReasonVitalRecords" name="Extension - Partial Date Absent Reason Vital Records"/>
-<artifact id="StructureDefinition/ExtensionPartialDateTimeVitalRecords" key="StructureDefinition-ExtensionPartialDateTimeVitalRecords" name="Extension - Partial Date Time Vital Records"/>
-<artifact id="StructureDefinition/ExtensionPartialDateVitalRecords" key="StructureDefinition-ExtensionPartialDateVitalRecords" name="Extension - Partial Date Vital Records"/>
-<artifact id="StructureDefinition/PostDirectional" key="StructureDefinition-PostDirectional" name="Extension - PostDirectional Vital Records"/>
-<artifact id="StructureDefinition/PreDirectional" key="StructureDefinition-PreDirectional" name="Extension - PreDirectional Vital Records"/>
-<artifact id="StructureDefinition/Extension-relatedperson-birthplace-vr" key="StructureDefinition-Extension-relatedperson-birthplace-vr" name="Extension - RelatedPerson Birth Place Vital Records"/>
-<artifact id="StructureDefinition/Extension-relatedperson-deceased-vr" key="StructureDefinition-Extension-relatedperson-deceased-vr" name="Extension - RelatedPerson Deceased Vital Records"/>
-<artifact id="StructureDefinition/StreetDesignator" key="StructureDefinition-StreetDesignator" name="Extension - StreetDesignator Vital Records"/>
-<artifact id="StructureDefinition/StreetName" key="StructureDefinition-StreetName" name="Extension - StreetName Vital Records"/>
-<artifact id="StructureDefinition/StreetNumber" key="StructureDefinition-StreetNumber" name="Extension - StreetNumber Vital Records"/>
 <artifact id="StructureDefinition/Extension-tracking-number" key="StructureDefinition-Extension-tracking-number" name="Extension - Tracking Number"/>
-<artifact id="StructureDefinition/UnitOrAptNumber" key="StructureDefinition-UnitOrAptNumber" name="Extension - UnitOrAptNumber Vital Records"/>
-<artifact id="StructureDefinition/Extension-within-city-limits-indicator-vr" key="StructureDefinition-Extension-within-city-limits-indicator-vr" name="Extension - Within City Limits Indicator Vital Records"/>
 <artifact id="RelatedPerson/FatherUT-Example1" key="RelatedPerson-FatherUT-Example1" name="FatherUT-Example1"/>
-<artifact id="ConceptMap/FetalDeathCauseOrConditionCM" key="ConceptMap-FetalDeathCauseOrConditionCM" name="FetalDeathCauseOrCondition Concept Map"/>
-<artifact id="ConceptMap/FetalDeathTimePointsCM" key="ConceptMap-FetalDeathTimePointsCM" name="FetalDeathTimePoints Concept Map"/>
-<artifact id="ConceptMap/FetalPresentationCM" key="ConceptMap-FetalPresentationCM" name="FetalPresentation Concept Map"/>
 <artifact id="StructureDefinition/FilingFormat" key="StructureDefinition-FilingFormat" name="Filing Format"/>
 <artifact id="ValueSet/vrdr-filing-format-vs" key="ValueSet-vrdr-filing-format-vs" name="Filing Format ValueSet"/>
 <artifact id="CodeSystem/vrdr-filing-format-cs" key="CodeSystem-vrdr-filing-format-cs" name="Filing Formats CodeSystem"/>
@@ -241,9 +129,7 @@
 <artifact id="StructureDefinition/vrdr-funeral-home" key="StructureDefinition-vrdr-funeral-home" name="Funeral Home"/>
 <artifact id="Organization/FuneralHome-Example1" key="Organization-FuneralHome-Example1" name="FuneralHome-Example1"/>
 <artifact id="Organization/FuneralHomeUT-Example1" key="Organization-FuneralHomeUT-Example1" name="FuneralHomeUT-Example1"/>
-<artifact id="ConceptMap/HistologicalPlacentalExaminationCM" key="ConceptMap-HistologicalPlacentalExaminationCM" name="HistologicalPlacentalExamination Concept Map"/>
 <artifact id="ValueSet/vrdr-icd10-causes-of-death-vs" key="ValueSet-vrdr-icd10-causes-of-death-vs" name="ICD10 Causes of Death VS"/>
-<artifact id="ConceptMap/InfectionsDuringPregnancyLiveBirthCM" key="ConceptMap-InfectionsDuringPregnancyLiveBirthCM" name="InfectionsDuringPregnancyLiveBirth Concept Map"/>
 <artifact id="StructureDefinition/vrdr-injury-location" key="StructureDefinition-vrdr-injury-location" name="Injury Location"/>
 <artifact id="Observation/InjuryIncident-Example1" key="Observation-InjuryIncident-Example1" name="InjuryIncident-Example1"/>
 <artifact id="Observation/InjuryIncident-Example2" key="Observation-InjuryIncident-Example2" name="InjuryIncident-Example2"/>
@@ -281,159 +167,17 @@
 <artifact id="Practitioner/Mortician-Example1" key="Practitioner-Mortician-Example1" name="Mortician-Example1"/>
 <artifact id="RelatedPerson/MotherUT-Example1" key="RelatedPerson-MotherUT-Example1" name="MotherUT-Example1"/>
 <artifact id="StructureDefinition/NVSS-SexAtDeath" key="StructureDefinition-NVSS-SexAtDeath" name="NVSS SexAtDeath"/>
-<artifact id="ConceptMap/NewbornCongenitalAnomaliesCM" key="ConceptMap-NewbornCongenitalAnomaliesCM" name="NewbornCongenitalAnomalies Concept Map"/>
-<artifact id="StructureDefinition/Observation-apgar-score" key="StructureDefinition-Observation-apgar-score" name="Observation - APGAR Score"/>
-<artifact id="StructureDefinition/Observation-steroids-fetal-lung-maturation" key="StructureDefinition-Observation-steroids-fetal-lung-maturation" name="Observation - Administration of Steroids for Fetal Lung Maturation"/>
-<artifact id="Observation/observation-steroids-fetal-lung-maturation-jada-ann-quinn" key="Observation-observation-steroids-fetal-lung-maturation-jada-ann-quinn" name="Observation - Administration of Steroids for Fetal Lung Maturation - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Observation-antibiotics-administered-during-labor" key="StructureDefinition-Observation-antibiotics-administered-during-labor" name="Observation - Antibiotics Administered During Labor"/>
-<artifact id="Observation/observation-antibiotics-during-labor-jada-ann-quinn" key="Observation-observation-antibiotics-during-labor-jada-ann-quinn" name="Observation - Antibiotics Administered During Labor - Jada Ann Quinn"/>
-<artifact id="Observation/observation-apgar-score-babyg-quinn-1-min" key="Observation-observation-apgar-score-babyg-quinn-1-min" name="Observation - Apgar Score - BabyG Quinn: 1 min"/>
-<artifact id="Observation/observation-apgar-score-babyg-quinn-5-min" key="Observation-observation-apgar-score-babyg-quinn-5-min" name="Observation - Apgar Score - BabyG Quinn: 5 min"/>
-<artifact id="Observation/observation-autopsy-performed-not-named" key="Observation-observation-autopsy-performed-not-named" name="Observation - Autopsy Performed - Fetus Not Named"/>
 <artifact id="Observation/observation-autopsy-performed-indicator-a-freeman" key="Observation-observation-autopsy-performed-indicator-a-freeman" name="Observation - Autopsy Performed Indicator - Freeman"/>
-<artifact id="StructureDefinition/Observation-autopsy-performed-indicator-vr" key="StructureDefinition-Observation-autopsy-performed-indicator-vr" name="Observation - Autopsy Performed Indicator Vital Records"/>
-<artifact id="Observation/observation-autopsy-performed-indicator-vr-a-freeman" key="Observation-observation-autopsy-performed-indicator-vr-a-freeman" name="Observation - Autopsy Performed Indicator example [A Freeman]"/>
-<artifact id="Observation/observation-autopsy-performed-not-named-common" key="Observation-observation-autopsy-performed-not-named-common" name="Observation - Autopsy Performed example [Fetus Not Named]"/>
-<artifact id="StructureDefinition/Observation-autopsy-histological-exam-results-used" key="StructureDefinition-Observation-autopsy-histological-exam-results-used" name="Observation - Autopsy or Histological Exam Results Used"/>
-<artifact id="Observation/observation-autopsy-histological-exam-results-used-not-named" key="Observation-observation-autopsy-histological-exam-results-used-not-named" name="Observation - Autopsy or Histological Exam Results Used - Fetus Not Named"/>
-<artifact id="StructureDefinition/Observation-birth-weight" key="StructureDefinition-Observation-birth-weight" name="Observation - Birth Weight"/>
-<artifact id="Observation/observation-birth-weight-babyg-quinn" key="Observation-observation-birth-weight-babyg-quinn" name="Observation - Birth Weight - Baby G Quinn"/>
-<artifact id="Observation/observation-birth-weight-babyg-quinn-w-edit" key="Observation-observation-birth-weight-babyg-quinn-w-edit" name="Observation - Birth Weight - Baby G Quinn, with Edit Flag"/>
-<artifact id="Observation/observation-birth-weight-not-named" key="Observation-observation-birth-weight-not-named" name="Observation - Birth Weight - Fetus Not Named"/>
-<artifact id="Observation/observation-birth-weight-not-named-w-edit" key="Observation-observation-birth-weight-not-named-w-edit" name="Observation - Birth Weight - Fetus Not Named, with Edit Flag"/>
 <artifact id="Observation/observation-cause-of-death-part1-a-freeman" key="Observation-observation-cause-of-death-part1-a-freeman" name="Observation - Cause of Death Part 1 - Freeman"/>
-<artifact id="Observation/observation-cig-smoking-pregnancy-1-carmen-teresa-lee" key="Observation-observation-cig-smoking-pregnancy-1-carmen-teresa-lee" name="Observation - Cigarette Smoking Before During Pregnancy - 3 months prior: Carmen Teresa Lee"/>
-<artifact id="Observation/observation-cig-smoking-pregnancy-2-carmen-teresa-lee" key="Observation-observation-cig-smoking-pregnancy-2-carmen-teresa-lee" name="Observation - Cigarette Smoking Before During Pregnancy - first 3 months: Carmen Teresa Lee"/>
-<artifact id="Observation/observation-cig-smoking-pregnancy-4-carmen-teresa-lee" key="Observation-observation-cig-smoking-pregnancy-4-carmen-teresa-lee" name="Observation - Cigarette Smoking Before During Pregnancy - last 3 months: Carmen Teresa Lee"/>
-<artifact id="Observation/observation-cig-smoking-pregnancy-3-carmen-teresa-lee" key="Observation-observation-cig-smoking-pregnancy-3-carmen-teresa-lee" name="Observation - Cigarette Smoking Before During Pregnancy example - second 3 months: Carmen Teresa Lee"/>
-<artifact id="StructureDefinition/Observation-cigarette-smoking-before-during-pregnancy" key="StructureDefinition-Observation-cigarette-smoking-before-during-pregnancy" name="Observation - Cigarette Smoking Before and During Pregnancy"/>
-<artifact id="Observation/observation-cig-smoking-pregnancy-1-jada-ann-quinn" key="Observation-observation-cig-smoking-pregnancy-1-jada-ann-quinn" name="Observation - Cigarette Smoking Before/During Pregnancy - Jada Ann Quinn: 3 months prior"/>
-<artifact id="Observation/observation-cig-smoking-pregnancy-2-jada-ann-quinn" key="Observation-observation-cig-smoking-pregnancy-2-jada-ann-quinn" name="Observation - Cigarette Smoking Before/During Pregnancy - Jada Ann Quinn: first 3 months"/>
-<artifact id="Observation/observation-cig-smoking-pregnancy-4-jada-ann-quinn" key="Observation-observation-cig-smoking-pregnancy-4-jada-ann-quinn" name="Observation - Cigarette Smoking Before/During Pregnancy - Jada Ann Quinn: last 3 months"/>
-<artifact id="Observation/observation-cig-smoking-pregnancy-3-jada-ann-quinn" key="Observation-observation-cig-smoking-pregnancy-3-jada-ann-quinn" name="Observation - Cigarette Smoking Before/During Pregnancy - Jada Ann Quinn: second 3 months"/>
-<artifact id="Observation/observation-coded-initiating-fetal-death-cause-or-condition" key="Observation-observation-coded-initiating-fetal-death-cause-or-condition" name="Observation - Coded Initiating Cause of Fetal Death"/>
-<artifact id="StructureDefinition/Observation-coded-initiating-fetal-death-cause-or-condition" key="StructureDefinition-Observation-coded-initiating-fetal-death-cause-or-condition" name="Observation - Coded Initiating Fetal Death Cause or Condition"/>
-<artifact id="Observation/observation-coded-other-fetal-death-cause-or-condition-not-named" key="Observation-observation-coded-other-fetal-death-cause-or-condition-not-named" name="Observation - Coded Other Cause of Fetal Death"/>
-<artifact id="StructureDefinition/Observation-coded-other-fetal-death-cause-or-condition" key="StructureDefinition-Observation-coded-other-fetal-death-cause-or-condition" name="Observation - Coded Other Fetal Death Cause or Condition"/>
-<artifact id="StructureDefinition/coded-race-and-ethnicity-vr" key="StructureDefinition-coded-race-and-ethnicity-vr" name="Observation - Coded Race and Ethnicity Vital Records"/>
-<artifact id="Observation/CodedRaceAndEthnicity-Father" key="Observation-CodedRaceAndEthnicity-Father" name="Observation - CodedRaceAndEthnicity example [Father]"/>
-<artifact id="Observation/CodedRaceAndEthnicity-Mother" key="Observation-CodedRaceAndEthnicity-Mother" name="Observation - CodedRaceAndEthnicity example [Mother]"/>
 <artifact id="Observation/observation-contributing-cause-of-death-part2-a-freeman" key="Observation-observation-contributing-cause-of-death-part2-a-freeman" name="Observation - Contributing Cause of Death Part 2 - Freeman"/>
-<artifact id="StructureDefinition/Observation-date-of-first-prenatal-care-visit" key="StructureDefinition-Observation-date-of-first-prenatal-care-visit" name="Observation - Date of First Prenatal Care Visit"/>
-<artifact id="Observation/observation-date-of-first-prenatal-care-visit-carmen-teresa-lee" key="Observation-observation-date-of-first-prenatal-care-visit-carmen-teresa-lee" name="Observation - Date of First Prenatal Care Visit - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-date-of-first-prenatal-care-visit-jada-ann-quinn" key="Observation-observation-date-of-first-prenatal-care-visit-jada-ann-quinn" name="Observation - Date of First Prenatal Care Visit - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Observation-date-of-last-live-birth" key="StructureDefinition-Observation-date-of-last-live-birth" name="Observation - Date of Last Live Birth"/>
-<artifact id="Observation/observation-date-of-last-live-birth-carmen-teresa-lee" key="Observation-observation-date-of-last-live-birth-carmen-teresa-lee" name="Observation - Date of Last Live Birth - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-date-of-last-live-birth-jada-ann-quinn" key="Observation-observation-date-of-last-live-birth-jada-ann-quinn" name="Observation - Date of Last Live Birth - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Observation-date-of-last-other-pregnancy-outcome" key="StructureDefinition-Observation-date-of-last-other-pregnancy-outcome" name="Observation - Date of Last Other Pregnancy Outcome"/>
-<artifact id="Observation/observation-date-of-last-other-pregnancy-outcome-jada-ann-quinn" key="Observation-observation-date-of-last-other-pregnancy-outcome-jada-ann-quinn" name="Observation - Date of Last Other Pregnancy Outcome - Jada Ann Quinn"/>
-<artifact id="Observation/observation-fetal-presentation-babyg-quinn" key="Observation-observation-fetal-presentation-babyg-quinn" name="Observation - Date of Last Other Pregnancy Outcome - Jada Ann Quinn"/>
 <artifact id="StructureDefinition/vrdr-death-date" key="StructureDefinition-vrdr-death-date" name="Observation - Death Date"/>
 <artifact id="Observation/observation-death-date-a-freeman" key="Observation-observation-death-date-a-freeman" name="Observation - Death Date - Freeman"/>
 <artifact id="StructureDefinition/vrdr-decedent-pregnancy-status" key="StructureDefinition-vrdr-decedent-pregnancy-status" name="Observation - Decedent Pregnancy"/>
 <artifact id="Observation/observation-decedent-pregnancy-a-freeman" key="Observation-observation-decedent-pregnancy-a-freeman" name="Observation - Decedent Pregnancy - Freeman"/>
 <artifact id="Observation/DecedentDispositionMethod-a-freeman" key="Observation-DecedentDispositionMethod-a-freeman" name="Observation - Disposition Method - Freeman"/>
-<artifact id="StructureDefinition/Observation-education-level-vr" key="StructureDefinition-Observation-education-level-vr" name="Observation - Education Level Vital Records"/>
-<artifact id="StructureDefinition/Observation-emerging-issues-vr" key="StructureDefinition-Observation-emerging-issues-vr" name="Observation - Emerging Issues Vital Records"/>
-<artifact id="StructureDefinition/Observation-fetal-death-time-point" key="StructureDefinition-Observation-fetal-death-time-point" name="Observation - Fetal Death Time Point"/>
-<artifact id="Observation/observation-fetal-presentation-not-named" key="Observation-observation-fetal-presentation-not-named" name="Observation - Fetal Presentation - Fetus Not Named"/>
-<artifact id="StructureDefinition/Observation-fetal-presentation" key="StructureDefinition-Observation-fetal-presentation" name="Observation - Fetal Presentation at Birth/Delivery"/>
-<artifact id="StructureDefinition/Observation-gestational-age-at-delivery" key="StructureDefinition-Observation-gestational-age-at-delivery" name="Observation - Gestational Age at Delivery"/>
-<artifact id="Observation/observation-gestational-age-at-delivery-babyg-quinn" key="Observation-observation-gestational-age-at-delivery-babyg-quinn" name="Observation - Gestational Age at Delivery - Baby G Quinn"/>
-<artifact id="Observation/observation-gestational-age-at-delivery-babyg-quinn-w-edit" key="Observation-observation-gestational-age-at-delivery-babyg-quinn-w-edit" name="Observation - Gestational Age at Delivery - Baby G Quinn, with Edit Flag"/>
-<artifact id="Observation/observation-gestational-age-at-delivery-not-named" key="Observation-observation-gestational-age-at-delivery-not-named" name="Observation - Gestational Age at Delivery - Fetus Not Named"/>
-<artifact id="Observation/observation-gestational-age-at-delivery-not-named-w-edit" key="Observation-observation-gestational-age-at-delivery-not-named-w-edit" name="Observation - Gestational Age at Delivery - Fetus Not Named, with Edit Flag"/>
-<artifact id="StructureDefinition/Observation-histological-placental-exam-performed" key="StructureDefinition-Observation-histological-placental-exam-performed" name="Observation - Histological Placental Exam Performed"/>
-<artifact id="Observation/observation-histological-placental-exam-performed-not-named" key="Observation-observation-histological-placental-exam-performed-not-named" name="Observation - Histological Placental Exam Performed - Fetus Not Named"/>
 <artifact id="Observation/observation-how-death-injury-occurred-a-freeman-med-ingest" key="Observation-observation-how-death-injury-occurred-a-freeman-med-ingest" name="Observation - How Death Injury Occurred - Freeman - Medication ingestion"/>
-<artifact id="StructureDefinition/Observation-icu-admission" key="StructureDefinition-Observation-icu-admission" name="Observation - ICU Admission"/>
-<artifact id="Observation/observation-icu-admission-jada-ann-quinn" key="Observation-observation-icu-admission-jada-ann-quinn" name="Observation - ICU Admission - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Observation-infant-breastfed-at-discharge" key="StructureDefinition-Observation-infant-breastfed-at-discharge" name="Observation - Infant Breastfed at Discharge"/>
-<artifact id="Observation/observation-infant-breastfed-at-discharge-babyg-quinn" key="Observation-observation-infant-breastfed-at-discharge-babyg-quinn" name="Observation - Infant Breastfed at Discharge - Baby G Quinn"/>
-<artifact id="StructureDefinition/Observation-infant-living" key="StructureDefinition-Observation-infant-living" name="Observation - Infant Living"/>
-<artifact id="Observation/observation-infant-living-babyg-quinn" key="Observation-observation-infant-living-babyg-quinn" name="Observation - Infant Living - Baby G Quinn"/>
 <artifact id="StructureDefinition/vrdr-injury-incident" key="StructureDefinition-vrdr-injury-incident" name="Observation - Injury Incident"/>
-<artifact id="StructureDefinition/input-race-and-ethnicity-vr" key="StructureDefinition-input-race-and-ethnicity-vr" name="Observation - Input Race and Ethnicity Vital Records"/>
-<artifact id="Observation/InputRaceAndEthnicityFather" key="Observation-InputRaceAndEthnicityFather" name="Observation - InputRaceAndEthnicity example [Father]"/>
-<artifact id="Observation/InputRaceAndEthnicityMother" key="Observation-InputRaceAndEthnicityMother" name="Observation - InputRaceAndEthnicity example [Mother]"/>
-<artifact id="StructureDefinition/Observation-labor-trial-attempted" key="StructureDefinition-Observation-labor-trial-attempted" name="Observation - Labor Trial Attempted"/>
-<artifact id="Observation/observation-labor-trial-attempted-babyg-quinn" key="Observation-observation-labor-trial-attempted-babyg-quinn" name="Observation - Labor Trial Attempted - Baby G Quinn"/>
-<artifact id="StructureDefinition/Observation-last-menstrual-period" key="StructureDefinition-Observation-last-menstrual-period" name="Observation - Last Menstrual Period"/>
-<artifact id="Observation/observation-last-menstrual-period-carmen-teresa-lee" key="Observation-observation-last-menstrual-period-carmen-teresa-lee" name="Observation - Last Menstrual Period - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-last-menstrual-period-jada-ann-quinn" key="Observation-observation-last-menstrual-period-jada-ann-quinn" name="Observation - Last Menstrual Period - Jada Ann Quinn"/>
 <artifact id="Observation/observation-manner-of-death-a-freeman-accidental" key="Observation-observation-manner-of-death-a-freeman-accidental" name="Observation - Manner of Death - Freeman"/>
-<artifact id="StructureDefinition/Observation-mother-delivery-weight" key="StructureDefinition-Observation-mother-delivery-weight" name="Observation - Mother Delivery Weight"/>
-<artifact id="Observation/observation-mother-delivery-weight-jada-ann-quinn" key="Observation-observation-mother-delivery-weight-jada-ann-quinn" name="Observation - Mother Delivery Weight - Jada Ann Quinn"/>
-<artifact id="Observation/observation-mother-delivery-weight-jada-ann-quinn-w-edit" key="Observation-observation-mother-delivery-weight-jada-ann-quinn-w-edit" name="Observation - Mother Delivery Weight - Jada Ann Quinn, with Edit Flag"/>
-<artifact id="StructureDefinition/Observation-mother-height" key="StructureDefinition-Observation-mother-height" name="Observation - Mother Height"/>
-<artifact id="Observation/observation-mother-height-carmen-teresa-lee" key="Observation-observation-mother-height-carmen-teresa-lee" name="Observation - Mother Height - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-mother-height-carmen-teresa-lee-w-edit" key="Observation-observation-mother-height-carmen-teresa-lee-w-edit" name="Observation - Mother Height - Carmen Teresa Lee, with Edit Flag"/>
-<artifact id="Observation/observation-mother-height-jada-ann-quinn" key="Observation-observation-mother-height-jada-ann-quinn" name="Observation - Mother Height - Jada Ann Quinn"/>
-<artifact id="Observation/observation-mother-height-jada-ann-quinn-w-edit" key="Observation-observation-mother-height-jada-ann-quinn-w-edit" name="Observation - Mother Height - Jada Ann Quinn, with Edit Flag"/>
-<artifact id="StructureDefinition/Observation-mother-married-during-pregnancy" key="StructureDefinition-Observation-mother-married-during-pregnancy" name="Observation - Mother Married During Pregnancy"/>
-<artifact id="Observation/observation-mother-married-during-pregnancy-jada-ann-quinn" key="Observation-observation-mother-married-during-pregnancy-jada-ann-quinn" name="Observation - Mother Married During Pregnancy - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Observation-mother-prepregnancy-weight" key="StructureDefinition-Observation-mother-prepregnancy-weight" name="Observation - Mother Prepregnancy Weight"/>
-<artifact id="Observation/observation-mother-prepregnancy-weight-carmen-teresa-lee" key="Observation-observation-mother-prepregnancy-weight-carmen-teresa-lee" name="Observation - Mother Prepregnancy Weight - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-mother-prepregnancy-weight-carmen-teresa-lee-w-edit" key="Observation-observation-mother-prepregnancy-weight-carmen-teresa-lee-w-edit" name="Observation - Mother Prepregnancy Weight - Carmen Teresa Lee, with Edit Flag"/>
-<artifact id="Observation/observation-mother-prepregnancy-weight-jada-ann-quinn" key="Observation-observation-mother-prepregnancy-weight-jada-ann-quinn" name="Observation - Mother Prepregnancy Weight - Jada Ann Quinn"/>
-<artifact id="Observation/observation-mother-prepregnancy-weight-jada-ann-quinn-w-edit" key="Observation-observation-mother-prepregnancy-weight-jada-ann-quinn-w-edit" name="Observation - Mother Prepregnancy Weight - Jada Ann Quinn, with Edit Flag"/>
-<artifact id="Observation/observation-mother-received-wic-food-carmen-teresa-lee" key="Observation-observation-mother-received-wic-food-carmen-teresa-lee" name="Observation - Mother Received WIC Food - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-mother-received-wic-food-jada-ann-quinn" key="Observation-observation-mother-received-wic-food-jada-ann-quinn" name="Observation - Mother Received WIC Food - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Observation-mother-received-wic-food" key="StructureDefinition-Observation-mother-received-wic-food" name="Observation - Mother Recieved WIC Food"/>
-<artifact id="StructureDefinition/Observation-nicu-admission" key="StructureDefinition-Observation-nicu-admission" name="Observation - NICU Admission"/>
-<artifact id="Observation/observation-nicu-admission-babyg-quinn" key="Observation-observation-nicu-admission-babyg-quinn" name="Observation - NICU Admission - BabyG Quinn"/>
-<artifact id="StructureDefinition/Observation-none-of-specified-abnormal-conditions-of-newborn" key="StructureDefinition-Observation-none-of-specified-abnormal-conditions-of-newborn" name="Observation - None Of Specified Abnormal Conditions of Newborn"/>
-<artifact id="Observation/observation-none-abnormal-conditions-babyg-quinn" key="Observation-observation-none-abnormal-conditions-babyg-quinn" name="Observation - None Of Specified Abnormal Conditions of Newborn - BabyG Quinn"/>
-<artifact id="StructureDefinition/Observation-none-of-specified-characteristics-of-labor-delivery" key="StructureDefinition-Observation-none-of-specified-characteristics-of-labor-delivery" name="Observation - None Of Specified Characteristics of Labor and Delivery"/>
-<artifact id="Observation/observation-none-chars-labor-delivery-jada-ann-quinn" key="Observation-observation-none-chars-labor-delivery-jada-ann-quinn" name="Observation - None Of Specified Characteristics of Labor and Delivery - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Observation-None-congenital-anomolies-of-the-newborn" key="StructureDefinition-Observation-None-congenital-anomolies-of-the-newborn" name="Observation - None Of Specified Congenital Anomolies Of The Newborn"/>
-<artifact id="StructureDefinition/Observation-no-infections-present-during-pregnancy" key="StructureDefinition-Observation-no-infections-present-during-pregnancy" name="Observation - None Of Specified Infections Specified During Pregnancy"/>
-<artifact id="StructureDefinition/Observation-none-of-specified-maternal-morbidities" key="StructureDefinition-Observation-none-of-specified-maternal-morbidities" name="Observation - None Of Specified Maternal Morbidities"/>
-<artifact id="Observation/observation-none-maternal-morbidities-jada-ann-quinn" key="Observation-observation-none-maternal-morbidities-jada-ann-quinn" name="Observation - None Of Specified Maternal Morbidities - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Observation-none-of-specified-obstetric-procedures" key="StructureDefinition-Observation-none-of-specified-obstetric-procedures" name="Observation - None Of Specified Obstetric Procedures"/>
-<artifact id="StructureDefinition/Observation-none-of-specified-pregnancy-risk-factors" key="StructureDefinition-Observation-none-of-specified-pregnancy-risk-factors" name="Observation - None Of Specified Pregnancy Risk Factors"/>
-<artifact id="Observation/observation-none-specified-risk-factors-jada-ann-quinn" key="Observation-observation-none-specified-risk-factors-jada-ann-quinn" name="Observation - None of Specified Risk Factors - Jada Ann Quinn"/>
-<artifact id="Observation/observation-number-births-now-dead-jada-ann-quinn" key="Observation-observation-number-births-now-dead-jada-ann-quinn" name="Observation - Number Births Now Dead - Jada Ann Quinn"/>
-<artifact id="Observation/observation-number-births-now-living-jada-ann-quinn" key="Observation-observation-number-births-now-living-jada-ann-quinn" name="Observation - Number Births Now Living - Jada Ann Quinn"/>
-<artifact id="Observation/observation-nbr-live-births-delivery-carmen-teresa-lee" key="Observation-observation-nbr-live-births-delivery-carmen-teresa-lee" name="Observation - Number Live Births This Delivery - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-number-live-births-this-delivery-carmen-teresa-lee" key="Observation-observation-number-live-births-this-delivery-carmen-teresa-lee" name="Observation - Number Live Births This Delivery - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-number-live-births-this-delivery-jada-ann-quinn" key="Observation-observation-number-live-births-this-delivery-jada-ann-quinn" name="Observation - Number Live Births This Delivery - Jada Ann Quinn"/>
-<artifact id="Observation/observation-nbr-other-pregnancy-outcomes-jada-ann-quinn" key="Observation-observation-nbr-other-pregnancy-outcomes-jada-ann-quinn" name="Observation - Number Other Pregnancy Outcomes - Jada Ann Quinn"/>
-<artifact id="Observation/observation-number-other-pregnancy-outcomes-jada-ann-quinn" key="Observation-observation-number-other-pregnancy-outcomes-jada-ann-quinn" name="Observation - Number Other Pregnancy Outcomes - Jada Ann Quinn"/>
-<artifact id="Observation/observation-number-prenatal-visits-jada-ann-quinn" key="Observation-observation-number-prenatal-visits-jada-ann-quinn" name="Observation - Number Prenatal Visits - Jada Ann Quinn"/>
-<artifact id="Observation/observation-number-prenatal-visits-jada-ann-quinn-w-edit" key="Observation-observation-number-prenatal-visits-jada-ann-quinn-w-edit" name="Observation - Number Prenatal Visits - Jada Ann Quinn, with Edit Flag"/>
-<artifact id="Observation/observation-number-previous-cesareans-jada-ann-quinn" key="Observation-observation-number-previous-cesareans-jada-ann-quinn" name="Observation - Number Previous Cesareans - Jada Ann Quinn"/>
-<artifact id="Observation/observation-number-previous-cesareans-jada-ann-quinn-w-edit" key="Observation-observation-number-previous-cesareans-jada-ann-quinn-w-edit" name="Observation - Number Previous Cesareans - Jada Ann Quinn, with Edit Flag"/>
-<artifact id="StructureDefinition/Observation-number-births-now-dead" key="StructureDefinition-Observation-number-births-now-dead" name="Observation - Number of Births Now Dead"/>
-<artifact id="Observation/observation-number-births-now-dead-carmen-teresa-lee" key="Observation-observation-number-births-now-dead-carmen-teresa-lee" name="Observation - Number of Births Now Dead - Carmen Teresa Lee"/>
-<artifact id="StructureDefinition/Observation-number-births-now-living" key="StructureDefinition-Observation-number-births-now-living" name="Observation - Number of Births Now Living"/>
-<artifact id="Observation/observation-number-births-now-living-carmen-teresa-lee" key="Observation-observation-number-births-now-living-carmen-teresa-lee" name="Observation - Number of Births Now Living - Carmen Teresa Lee"/>
-<artifact id="StructureDefinition/Observation-number-fetal-deaths-this-delivery" key="StructureDefinition-Observation-number-fetal-deaths-this-delivery" name="Observation - Number of Fetal Deaths This Delivery"/>
-<artifact id="Observation/observation-number-deaths-this-delivery-carmen-teresa-lee" key="Observation-observation-number-deaths-this-delivery-carmen-teresa-lee" name="Observation - Number of Fetal Deaths This Delivery - Carmen Teresa Lee"/>
-<artifact id="StructureDefinition/Observation-number-live-births-this-delivery" key="StructureDefinition-Observation-number-live-births-this-delivery" name="Observation - Number of Live Births This Delivery"/>
-<artifact id="StructureDefinition/Observation-number-other-pregnancy-outcomes" key="StructureDefinition-Observation-number-other-pregnancy-outcomes" name="Observation - Number of Other Pregnancy Outcomes"/>
-<artifact id="StructureDefinition/Observation-number-prenatal-visits" key="StructureDefinition-Observation-number-prenatal-visits" name="Observation - Number of Prenatal Visits"/>
-<artifact id="StructureDefinition/Observation-number-previous-cesareans" key="StructureDefinition-Observation-number-previous-cesareans" name="Observation - Number of Previous Cesareans"/>
-<artifact id="Observation/observation-fetal-death-time-point-not-named" key="Observation-observation-fetal-death-time-point-not-named" name="Observation - Observation Estimated Fetal Death Time Point - Fetus Not Named"/>
-<artifact id="Observation/observation-parent-education-level-carmen-teresa-lee" key="Observation-observation-parent-education-level-carmen-teresa-lee" name="Observation - Parent Education Level - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-parent-education-level-carmen-teresa-lee-w-edit" key="Observation-observation-parent-education-level-carmen-teresa-lee-w-edit" name="Observation - Parent Education Level - Carmen Teresa Lee, with Edit Flag"/>
-<artifact id="Observation/observation-parent-education-level-jada-ann-quinn" key="Observation-observation-parent-education-level-jada-ann-quinn" name="Observation - Parent Education Level - Jada Ann Quinn"/>
-<artifact id="Observation/observation-parent-education-level-jada-ann-quinn-w-edit" key="Observation-observation-parent-education-level-jada-ann-quinn-w-edit" name="Observation - Parent Education Level - Jada Ann Quinn, with Edit Flag"/>
-<artifact id="Observation/observation-parent-education-level-james-quinn" key="Observation-observation-parent-education-level-james-quinn" name="Observation - Parent Education Level - James Quinn"/>
-<artifact id="Observation/observation-parent-education-level-james-quinn-w-edit" key="Observation-observation-parent-education-level-james-quinn-w-edit" name="Observation - Parent Education Level - James Quinn, with Edit Flag"/>
-<artifact id="Observation/observation-parent-education-level-tom-yan-lee" key="Observation-observation-parent-education-level-tom-yan-lee" name="Observation - Parent Education Level - Tom Yan Lee"/>
-<artifact id="Observation/observation-parent-education-level-tom-yan-lee-w-edit" key="Observation-observation-parent-education-level-tom-yan-lee-w-edit" name="Observation - Parent Education Level - Tom Yan Lee, with Edit Flag"/>
-<artifact id="StructureDefinition/Observation-paternity-acknowledgement-signed" key="StructureDefinition-Observation-paternity-acknowledgement-signed" name="Observation - Paternity Acknowledgement Signed"/>
-<artifact id="Observation/observation-paternity-acknowledgement-signed-james-quinn" key="Observation-observation-paternity-acknowledgement-signed-james-quinn" name="Observation - Paternity Acknowledgement Signed - James Quinn"/>
-<artifact id="StructureDefinition/Observation-planned-to-deliver-at-home" key="StructureDefinition-Observation-planned-to-deliver-at-home" name="Observation - Planned to Deliver at Home"/>
-<artifact id="Observation/observation-planned-to-deliver-at-home-babyg-quinn" key="Observation-observation-planned-to-deliver-at-home-babyg-quinn" name="Observation - Planned to Deliver at Home - Baby G Quinn"/>
-<artifact id="Observation/observation-planned-to-deliver-at-home-not-named" key="Observation-observation-planned-to-deliver-at-home-not-named" name="Observation - Planned to Delivery at Home - Fetus Not Named"/>
-<artifact id="StructureDefinition/Observation-previous-cesarean" key="StructureDefinition-Observation-previous-cesarean" name="Observation - Previous Cesarean"/>
-<artifact id="Observation/observation-previous-cesarean-jada-ann-quinn" key="Observation-observation-previous-cesarean-jada-ann-quinn" name="Observation - Previous Cesarean - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Observation-previous-preterm-birth" key="StructureDefinition-Observation-previous-preterm-birth" name="Observation - Previous Preterm Birth"/>
-<artifact id="Observation/observation-previous-preterm-births-jada-ann-quinn" key="Observation-observation-previous-preterm-births-jada-ann-quinn" name="Observation - Previous Preterm Births - Jada Ann Quinn"/>
-<artifact id="Observation/observation-ssn-requested-for-child-babyg-quinn" key="Observation-observation-ssn-requested-for-child-babyg-quinn" name="Observation - SSN Requested for Child - BabyG Quinn"/>
-<artifact id="StructureDefinition/Observation-ssn-requested-for-child" key="StructureDefinition-Observation-ssn-requested-for-child" name="Observation - Social Security Number Requested For Child"/>
 <artifact id="Observation/observation-tobacco-use-a-freeman" key="Observation-observation-tobacco-use-a-freeman" name="Observation - Tobacco Use - Freeman"/>
 <artifact id="StructureDefinition/Observation-toxicology-lab-result" key="StructureDefinition-Observation-toxicology-lab-result" name="Observation - Toxicology Lab Result"/>
 <artifact id="Observation/us-core-lab-result-4-anpp-blood-a-freeman" key="Observation-us-core-lab-result-4-anpp-blood-a-freeman" name="Observation - Toxicology Lab Result - 4-anpp Blood Freeman"/>
@@ -447,89 +191,22 @@
 <artifact id="Observation/us-core-lab-result-fentanyl-urine-a-freeman" key="Observation-us-core-lab-result-fentanyl-urine-a-freeman" name="Observation - Toxicology Lab Result - Fentanyl Urine Freeman"/>
 <artifact id="Observation/us-core-lab-result-norfentanyl-urine-a-freeman" key="Observation-us-core-lab-result-norfentanyl-urine-a-freeman" name="Observation - Toxicology Lab Result - Norfentanyl Urine Freeman"/>
 <artifact id="Observation/us-core-lab-result-xylazine-urine-a-freeman" key="Observation-us-core-lab-result-xylazine-urine-a-freeman" name="Observation - Toxicology Lab Result - Xylazine Urine Freeman"/>
-<artifact id="StructureDefinition/Observation-unknown-final-route-and-method-of-delivery" key="StructureDefinition-Observation-unknown-final-route-and-method-of-delivery" name="Observation - Unknown Final Route and Method of Delivery"/>
-<artifact id="Observation/observation-number-previous-cesareans-carmen-teresa-lee" key="Observation-observation-number-previous-cesareans-carmen-teresa-lee" name="Observations - Number Previous Cesareans - Carmen Teresa Lee"/>
-<artifact id="Observation/observation-number-previous-cesareans-carmen-teresa-lee-w-edit" key="Observation-observation-number-previous-cesareans-carmen-teresa-lee-w-edit" name="Observations - Number Previous Cesareans - Carmen Teresa Lee, with Edit Flag"/>
 <artifact id="Parameters/expansion-parameters-mdi" key="Parameters-expansion-parameters-mdi" name="Parameters - SNOMED US Version"/>
-<artifact id="StructureDefinition/Patient-child-vr" key="StructureDefinition-Patient-child-vr" name="Patient - Child Vital Records"/>
-<artifact id="Patient/patient-child-babyg-quinn" key="Patient-patient-child-babyg-quinn" name="Patient - Child example [Baby G Quinn]"/>
-<artifact id="Patient/patient-child-babyg-quinn-w-edit" key="Patient-patient-child-babyg-quinn-w-edit" name="Patient - Child example [Baby G Quinn], with Edit Flag"/>
-<artifact id="StructureDefinition/Patient-decedent-fetus" key="StructureDefinition-Patient-decedent-fetus" name="Patient - Decedent Fetus"/>
-<artifact id="Patient/patient-decedent-fetus-not-named" key="Patient-patient-decedent-fetus-not-named" name="Patient - Decedent Fetus example [Fetus Not Named]"/>
-<artifact id="Patient/patient-decedent-fetus-not-named-w-edit" key="Patient-patient-decedent-fetus-not-named-w-edit" name="Patient - Decedent Fetus example [Fetus Not Named], with Edit Flag"/>
-<artifact id="Patient/patient-mother-birth-date-part-absent" key="Patient-patient-mother-birth-date-part-absent" name="Patient - Mother Date Part Absent"/>
-<artifact id="Patient/patient-mother-jada-ann-quinn" key="Patient-patient-mother-jada-ann-quinn" name="Patient - Mother Jada Ann Quinn"/>
-<artifact id="Patient/patient-mother-jada-ann-quinn-w-edit" key="Patient-patient-mother-jada-ann-quinn-w-edit" name="Patient - Mother Jada Ann Quinn, with Edit Flag"/>
-<artifact id="StructureDefinition/Patient-mother-vr" key="StructureDefinition-Patient-mother-vr" name="Patient - Mother Vital Records"/>
-<artifact id="Patient/patient-mother-carmen-teresa-lee" key="Patient-patient-mother-carmen-teresa-lee" name="Patient - Mother example [Carmen Teresa Lee]"/>
-<artifact id="Patient/patient-mother-carmen-teresa-lee-w-edit" key="Patient-patient-mother-carmen-teresa-lee-w-edit" name="Patient - Mother example [Carmen Teresa Lee], with Edit Flag"/>
-<artifact id="StructureDefinition/Patient-vr" key="StructureDefinition-Patient-vr" name="Patient - Vital Records"/>
 <artifact id="StructureDefinition/vrdr-place-of-injury" key="StructureDefinition-vrdr-place-of-injury" name="Place Of Injury"/>
 <artifact id="ValueSet/vrdr-place-of-death-vs" key="ValueSet-vrdr-place-of-death-vs" name="Place of Death VS -- PHVS_PlaceOfDeath_NCHS"/>
 <artifact id="ValueSet/vrdr-place-of-injury-vs" key="ValueSet-vrdr-place-of-injury-vs" name="Place of Injury VS"/>
 <artifact id="ConceptMap/PlaceOfDeathCM" key="ConceptMap-PlaceOfDeathCM" name="PlaceOfDeath Concept Map"/>
 <artifact id="ConceptMap/PlaceOfInjuryCM" key="ConceptMap-PlaceOfInjuryCM" name="PlaceOfInjury Concept Map"/>
 <artifact id="Observation/PlaceOfInjury-Example1" key="Observation-PlaceOfInjury-Example1" name="PlaceOfInjury-Example1"/>
-<artifact id="StructureDefinition/Practitioner-vr" key="StructureDefinition-Practitioner-vr" name="Practitioner - Vital Records"/>
-<artifact id="Practitioner/practitioner-vital-records-avery-jones" key="Practitioner-practitioner-vital-records-avery-jones" name="Practitioner - Vital Records - Avery Jones, MD"/>
 <artifact id="Practitioner/practitioner-vital-records-janet-seito" key="Practitioner-practitioner-vital-records-janet-seito" name="Practitioner - Vital Records - Janet Seito"/>
-<artifact id="Practitioner/practitioner-vital-records-jessica-leung" key="Practitioner-practitioner-vital-records-jessica-leung" name="Practitioner - Vital Records - Jessica Leung"/>
 <artifact id="Practitioner/PractitionerUT-Example1" key="Practitioner-PractitionerUT-Example1" name="PractitionerUT-Example1"/>
 <artifact id="Observation/PregnancyUT-Example1" key="Observation-PregnancyUT-Example1" name="PregnancyUT-Example1"/>
-<artifact id="StructureDefinition/Procedure-antibiotics-suspected-neonatal-sepsis" key="StructureDefinition-Procedure-antibiotics-suspected-neonatal-sepsis" name="Procedure - Antibiotic for Suspected Neonatal Sepsis"/>
-<artifact id="Procedure/procedure-antibiotic-sepsis-babyg-quinn" key="Procedure-procedure-antibiotic-sepsis-babyg-quinn" name="Procedure - Antibiotic for Suspected Neonatal Sepsis - BabyG Quinn"/>
-<artifact id="StructureDefinition/Procedure-artificial-insemination" key="StructureDefinition-Procedure-artificial-insemination" name="Procedure - Artificial Insemination"/>
-<artifact id="Procedure/procedure-assisted-fertilization-jada-ann-quinn" key="Procedure-procedure-assisted-fertilization-jada-ann-quinn" name="Procedure - Assisted Fertilization - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Procedure-assisted-ventilation-following-delivery" key="StructureDefinition-Procedure-assisted-ventilation-following-delivery" name="Procedure - Assisted Ventilation Following Delivery"/>
-<artifact id="Procedure/procedure-ventilation-following-babyg-quinn" key="Procedure-procedure-ventilation-following-babyg-quinn" name="Procedure - Assisted Ventilation Following Delivery - BabyG Quinn"/>
-<artifact id="StructureDefinition/Procedure-assisted-ventilation-more-than-six-hours" key="StructureDefinition-Procedure-assisted-ventilation-more-than-six-hours" name="Procedure - Assisted Ventilation More Than Six Hours"/>
-<artifact id="Procedure/procedure-ventilation-more-6-hours-babyg-quinn" key="Procedure-procedure-ventilation-more-6-hours-babyg-quinn" name="Procedure - Assisted Ventilation More Than Six Hours - BabyG Quinn"/>
-<artifact id="StructureDefinition/Procedure-augmentation-of-labor" key="StructureDefinition-Procedure-augmentation-of-labor" name="Procedure - Augmentation of Labor"/>
-<artifact id="Procedure/procedure-augmentation-of-labor-quinn" key="Procedure-procedure-augmentation-of-labor-quinn" name="Procedure - Augmentation of Labor - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Procedure-blood-transfusion" key="StructureDefinition-Procedure-blood-transfusion" name="Procedure - Blood Transfusion"/>
-<artifact id="Procedure/procedure-blood-transfusion-jada-ann-quinn" key="Procedure-procedure-blood-transfusion-jada-ann-quinn" name="Procedure - Blood Transfusion - Jada Ann Quinn"/>
 <artifact id="Procedure/procedure-death-certification-a-freeman" key="Procedure-procedure-death-certification-a-freeman" name="Procedure - Death Certification - Freeman"/>
 <artifact id="Procedure/procedure-death-certification-vr-a-freeman" key="Procedure-procedure-death-certification-vr-a-freeman" name="Procedure - Death Certification Vital Records - A Freeman"/>
-<artifact id="StructureDefinition/Procedure-epidural-or-spinal-anesthesia" key="StructureDefinition-Procedure-epidural-or-spinal-anesthesia" name="Procedure - Epidural or Spinal Anesthesia"/>
-<artifact id="Procedure/procedure-epidural-or-spinal-anesthesia-jada-ann-quinn" key="Procedure-procedure-epidural-or-spinal-anesthesia-jada-ann-quinn" name="Procedure - Epidural or Spinal Anesthesia - Jada Ann Quinn"/>
-<artifact id="Procedure/procedure-final-route-method-delivery-not-named" key="Procedure-procedure-final-route-method-delivery-not-named" name="Procedure - Final Route / Method of Delivery - Fetus Not Named"/>
-<artifact id="StructureDefinition/Procedure-final-route-method-delivery" key="StructureDefinition-Procedure-final-route-method-delivery" name="Procedure - Final Route and Method of Delivery"/>
-<artifact id="Procedure/procedure-final-route-method-delivery-babyg-quinn" key="Procedure-procedure-final-route-method-delivery-babyg-quinn" name="Procedure - Final Route and Method of Delivery - Baby G Quinn"/>
-<artifact id="StructureDefinition/Procedure-induction-of-labor" key="StructureDefinition-Procedure-induction-of-labor" name="Procedure - Induction of Labor"/>
-<artifact id="Procedure/procedure-induction-of-labor-jada-ann-quinn" key="Procedure-procedure-induction-of-labor-jada-ann-quinn" name="Procedure - Induction of Labor - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Procedure-infertility-treatment" key="StructureDefinition-Procedure-infertility-treatment" name="Procedure - Infertility Treatment"/>
-<artifact id="Procedure/procedure-infertility-treatment-jada-ann-quinn" key="Procedure-procedure-infertility-treatment-jada-ann-quinn" name="Procedure - Infertility Treatment - Jada Ann Quinn"/>
-<artifact id="StructureDefinition/Procedure-obstetric" key="StructureDefinition-Procedure-obstetric" name="Procedure - Obstetric"/>
-<artifact id="Procedure/procedure-obstetric-procedure-jada-ann-quinn" key="Procedure-procedure-obstetric-procedure-jada-ann-quinn" name="Procedure - Obstetric Procedure - Jada Ann Quinn"/>
-<artifact id="Procedure/procedure-surfactant-replacement-babyg-quinn" key="Procedure-procedure-surfactant-replacement-babyg-quinn" name="Procedure - Surfactant Replacement - BabyG Quinn"/>
-<artifact id="StructureDefinition/Procedure-surfactant-replacement-therapy" key="StructureDefinition-Procedure-surfactant-replacement-therapy" name="Procedure - Surfactant Replacement Therapy"/>
-<artifact id="StructureDefinition/Procedure-unplanned-hysterectomy" key="StructureDefinition-Procedure-unplanned-hysterectomy" name="Procedure - Unplanned Hysterectomy"/>
-<artifact id="StructureDefinition/Procedure-assisted-fertilization" key="StructureDefinition-Procedure-assisted-fertilization" name="Procedure - assisted Fertilization"/>
-<artifact id="Procedure/procedure-unplanned-hysterectomy-quinn" key="Procedure-procedure-unplanned-hysterectomy-quinn" name="Procedure Unplanned Hysterectomy - Jada Ann Quinn"/>
 <artifact id="Procedure/ProcedureDeathCertificationUT-Example1" key="Procedure-ProcedureDeathCertificationUT-Example1" name="ProcedureDeathCertificationUT-Example1"/>
-<artifact id="Procedure/procedure-artificial-insemination-jada-ann-quinn" key="Procedure-procedure-artificial-insemination-jada-ann-quinn" name="Prodecure - Artificial Insemniation - Jada Ann Quinn"/>
-<artifact id="Questionnaire/Questionnaire-mothers-live-birth" key="Questionnaire-Questionnaire-mothers-live-birth" name="Questionnaire - Mother's Worksheet for Child's Birth Certificate"/>
-<artifact id="Questionnaire/Questionnaire-patients-fetal-death" key="Questionnaire-Questionnaire-patients-fetal-death" name="Questionnaire - Patient's Fetal Death Worksheet"/>
-<artifact id="QuestionnaireResponse/QuestionnaireResponse-mothers-live-birth-jada-quinn" key="QuestionnaireResponse-QuestionnaireResponse-mothers-live-birth-jada-quinn" name="QuestionnaireResponse - Mother's Worksheet for Child's Birth Certificate: Jada Ann Quinn"/>
-<artifact id="QuestionnaireResponse/QuestionnaireResponse-patients-fetal-death-carmen-lee" key="QuestionnaireResponse-QuestionnaireResponse-patients-fetal-death-carmen-lee" name="QuestionnaireResponse - Patient's Fetal Death Worksheet: Carmen Lee"/>
 <artifact id="StructureDefinition/vrdr-record-axis-cause-of-death" key="StructureDefinition-vrdr-record-axis-cause-of-death" name="Record Axis Cause Of Death"/>
 <artifact id="Observation/RecordAxisCauseOfDeath-Example1" key="Observation-RecordAxisCauseOfDeath-Example1" name="RecordAxisCauseOfDeath-Example1"/>
 <artifact id="Observation/RecordAxisCauseOfDeath-Example2" key="Observation-RecordAxisCauseOfDeath-Example2" name="RecordAxisCauseOfDeath-Example2"/>
-<artifact id="StructureDefinition/RelatedPerson-parent-vr" key="StructureDefinition-RelatedPerson-parent-vr" name="Related Person - Parent Vital Records"/>
-<artifact id="RelatedPerson/relatedperson-father-tony-lewis-common" key="RelatedPerson-relatedperson-father-tony-lewis-common" name="RelatedPerson - Adoptive Father example [Tony Lewis]"/>
-<artifact id="RelatedPerson/relatedperson-mother-carol-hoffer-common" key="RelatedPerson-relatedperson-mother-carol-hoffer-common" name="RelatedPerson - Adoptive Mother example [Carol Hoffer]"/>
-<artifact id="RelatedPerson/relatedperson-father-natural-james-brandon-quinn" key="RelatedPerson-relatedperson-father-natural-james-brandon-quinn" name="RelatedPerson - Father Natural - Vital Records - James Brandon Quinn"/>
-<artifact id="RelatedPerson/relatedperson-father-natural-james-brandon-quinn-w-edit" key="RelatedPerson-relatedperson-father-natural-james-brandon-quinn-w-edit" name="RelatedPerson - Father Natural - Vital Records - James Brandon Quinn, with Edit Flag"/>
-<artifact id="RelatedPerson/relatedperson-father-natural-tom-yan-lee" key="RelatedPerson-relatedperson-father-natural-tom-yan-lee" name="RelatedPerson - Father Natural - Vital Records - Tom Yan Lee"/>
-<artifact id="RelatedPerson/relatedperson-father-natural-tom-yan-lee-w-edit" key="RelatedPerson-relatedperson-father-natural-tom-yan-lee-w-edit" name="RelatedPerson - Father Natural - Vital Records - Tom Yan Lee, with Edit Flag"/>
-<artifact id="StructureDefinition/RelatedPerson-father-natural-vr" key="StructureDefinition-RelatedPerson-father-natural-vr" name="RelatedPerson - Father Natural Vital Records"/>
-<artifact id="StructureDefinition/RelatedPerson-father-vr" key="StructureDefinition-RelatedPerson-father-vr" name="RelatedPerson - Father Vital Records"/>
-<artifact id="RelatedPerson/relatedperson-father-tom-yan-lee-common" key="RelatedPerson-relatedperson-father-tom-yan-lee-common" name="RelatedPerson - Father example [Tom Yan Lee]"/>
-<artifact id="RelatedPerson/relatedperson-mother-carmen-teresa-lee" key="RelatedPerson-relatedperson-mother-carmen-teresa-lee" name="RelatedPerson - Mother Gestational - Vital Records - Carmen Teresa Lee"/>
-<artifact id="RelatedPerson/relatedperson-mother-jada-ann-quinn" key="RelatedPerson-relatedperson-mother-jada-ann-quinn" name="RelatedPerson - Mother Gestational - Vital Records - Jada Ann Quinn"/>
-<artifact id="RelatedPerson/relatedperson-mother-gestational-carmen-teresa-lee-common" key="RelatedPerson-relatedperson-mother-gestational-carmen-teresa-lee-common" name="RelatedPerson - Mother Gestational example [Carmen Teresa Lee]"/>
-<artifact id="StructureDefinition/RelatedPerson-mother-vr" key="StructureDefinition-RelatedPerson-mother-vr" name="RelatedPerson - Mother Vital Records"/>
-<artifact id="RelatedPerson/relatedperson-parent-stepmother" key="RelatedPerson-relatedperson-parent-stepmother" name="RelatedPerson - Stepmother example [Susan Grant]"/>
 <artifact id="ConceptMap/ReplaceStatusCM" key="ConceptMap-ReplaceStatusCM" name="ReplaceStatus Concept Map"/>
 <artifact id="ValueSet/vrdr-replace-status-vs" key="ValueSet-vrdr-replace-status-vs" name="Replacement Status VS"/>
 <artifact id="CodeSystem/vrdr-replace-status-cs" key="CodeSystem-vrdr-replace-status-cs" name="Replacement Status of Death Record Submission"/>
@@ -558,86 +235,19 @@
 <artifact id="ConceptMap/TransaxConversionCM" key="ConceptMap-TransaxConversionCM" name="TransaxConversion Concept Map"/>
 <artifact id="ValueSet/vrdr-transportation-incident-role-vs" key="ValueSet-vrdr-transportation-incident-role-vs" name="Transportation Incident Role"/>
 <artifact id="ConceptMap/TransportationIncidentRoleCM" key="ConceptMap-TransportationIncidentRoleCM" name="TransportationIncidentRole Concept Map"/>
-<artifact id="Location/location-east-hospital" key="Location-location-east-hospital" name="US Core Location - East Hospital"/>
-<artifact id="Location/location-north-hospital" key="Location-location-north-hospital" name="US Core Location - North Hospital"/>
-<artifact id="Location/location-south-hospital" key="Location-location-south-hospital" name="US Core Location - South Hospital"/>
-<artifact id="Organization/organization-jurisdictional-vital-records-office" key="Organization-organization-jurisdictional-vital-records-office" name="US Core Organization - Jurisdictional Vital Records Office"/>
-<artifact id="Organization/organization-nchs" key="Organization-organization-nchs" name="US Core Organization - National Center for Health Statistics [NCHS]"/>
-<artifact id="Organization/organization-south-hospital" key="Organization-organization-south-hospital" name="US Core Organization - South Hospital"/>
 <artifact id="Organization/us-core-organization-tox-lab" key="Organization-us-core-organization-tox-lab" name="US Core Organization - UF Health Pathology Labs, Forensic Toxicology Laboratory"/>
 <artifact id="Patient/us-core-patient-a-freeman" key="Patient-us-core-patient-a-freeman" name="US Core Patient - Alice J. Freeman"/>
 <artifact id="Patient/us-core-patient-unknown-name" key="Patient-us-core-patient-unknown-name" name="US Core Patient - Unknown Name"/>
 <artifact id="Practitioner/us-core-practitioner-b-goldberger" key="Practitioner-us-core-practitioner-b-goldberger" name="US Core Practitioner - Dr. Bruce Goldberger"/>
 <artifact id="Practitioner/us-core-practitioner-j-jones" key="Practitioner-us-core-practitioner-j-jones" name="US Core Practitioner - Dr. Jane Jones"/>
 <artifact id="Practitioner/us-core-practitioner-s-jones" key="Practitioner-us-core-practitioner-s-jones" name="US Core Practitioner - Dr. Sam Jones"/>
-<artifact id="Parameters/expansion-parameters-bfdr" key="Parameters-expansion-parameters-bfdr" name="USA SNOMED-CT"/>
 <artifact id="Patient/us-core-patient-vr-a-freeman" key="Patient-us-core-patient-vr-a-freeman" name="USCorePatient - Patient example [A Freeman]"/>
-<artifact id="Patient/us-core-patient-vr-unknown-name" key="Patient-us-core-patient-vr-unknown-name" name="USCorePatient - Patient example [Unknown Name]"/>
 <artifact id="Observation/UsualWorkUT-Example1" key="Observation-UsualWorkUT-Example1" name="UsualWorkUT-Example1"/>
-<artifact id="ValueSet/ValueSet-apgar-timing" key="ValueSet-ValueSet-apgar-timing" name="ValueSet - APGAR Score Timing"/>
-<artifact id="ValueSet/ValueSet-birth-attendant-titles" key="ValueSet-ValueSet-birth-attendant-titles" name="ValueSet - Birth Attendants Titles"/>
-<artifact id="ValueSet/ValueSet-birth-delivery-occurred" key="ValueSet-ValueSet-birth-delivery-occurred" name="ValueSet - Birth Delivery Occurred"/>
-<artifact id="ValueSet/ValueSet-birth-sex-child-vr" key="ValueSet-ValueSet-birth-sex-child-vr" name="ValueSet - Birth Sex Child Vital Records"/>
-<artifact id="ValueSet/ValueSet-birth-sex-fetus-vr" key="ValueSet-ValueSet-birth-sex-fetus-vr" name="ValueSet - Birth Sex Fetus Vital Records"/>
-<artifact id="ValueSet/ValueSet-birth-weight-edit-flags" key="ValueSet-ValueSet-birth-weight-edit-flags" name="ValueSet - Birth Weight Edit Flags (NCHS)"/>
-<artifact id="ValueSet/ValueSet-birth-and-fetal-death-financial-class" key="ValueSet-ValueSet-birth-and-fetal-death-financial-class" name="ValueSet - Birth and Fetal Death Financial Class"/>
-<artifact id="ValueSet/ValueSet-birthplace-country-vr" key="ValueSet-ValueSet-birthplace-country-vr" name="ValueSet - Birthplace Country Vital Records"/>
-<artifact id="ValueSet/cigarette-smoking-before-during-pregnancy" key="ValueSet-cigarette-smoking-before-during-pregnancy" name="ValueSet - Cigarette Smoking Before and During Pregnancy"/>
-<artifact id="ValueSet/ValueSet-coded-race-and-ethnicity-person-vr" key="ValueSet-ValueSet-coded-race-and-ethnicity-person-vr" name="ValueSet - Coded Race and Ethnicity Person Vital Records"/>
 <artifact id="ValueSet/ValueSet-death-pregnancy-status" key="ValueSet-ValueSet-death-pregnancy-status" name="ValueSet - Death Pregnancy Status"/>
-<artifact id="ValueSet/ValueSet-delivery-routes" key="ValueSet-ValueSet-delivery-routes" name="ValueSet - Delivery Routes"/>
-<artifact id="ValueSet/ValueSet-education-level-person-vr" key="ValueSet-ValueSet-education-level-person-vr" name="ValueSet - Education Level Person Vital Records"/>
-<artifact id="ValueSet/ValueSet-education-level-vr" key="ValueSet-ValueSet-education-level-vr" name="ValueSet - Education Level Vital Records"/>
-<artifact id="ValueSet/ValueSet-estimate-of-gestation-edit-flags" key="ValueSet-ValueSet-estimate-of-gestation-edit-flags" name="ValueSet - Estimate of Gestation Edit Flags (NCHS)"/>
-<artifact id="ValueSet/ValueSet-father-relationship-vr" key="ValueSet-ValueSet-father-relationship-vr" name="ValueSet - Father Relationship Vital Records"/>
-<artifact id="ValueSet/ValueSet-fathers-date-of-birth-edit-flags" key="ValueSet-ValueSet-fathers-date-of-birth-edit-flags" name="ValueSet - Fathers Date of Birth Edit Flags (NCHS)"/>
-<artifact id="ValueSet/ValueSet-fetal-death-cause-or-condition" key="ValueSet-ValueSet-fetal-death-cause-or-condition" name="ValueSet - Fetal Death Cause or Condition"/>
-<artifact id="ValueSet/ValueSet-fetal-death-time-points" key="ValueSet-ValueSet-fetal-death-time-points" name="ValueSet - Fetal Death Time Points"/>
-<artifact id="ValueSet/ValueSet-fetal-presentations" key="ValueSet-ValueSet-fetal-presentations" name="ValueSet - Fetal Presentations"/>
-<artifact id="ValueSet/ValueSet-hispanic-no-unknown-vr" key="ValueSet-ValueSet-hispanic-no-unknown-vr" name="ValueSet - Hispanic(Yes) No Unknown Vital Records"/>
-<artifact id="ValueSet/ValueSet-hispanic-origin-vr" key="ValueSet-ValueSet-hispanic-origin-vr" name="ValueSet - HispanicOrigin Vital Records"/>
-<artifact id="ValueSet/ValueSet-histological-placental-examination" key="ValueSet-ValueSet-histological-placental-examination" name="ValueSet - Histological Placental Examination"/>
-<artifact id="ValueSet/ValueSet-infections-during-pregnancy-live-birth" key="ValueSet-ValueSet-infections-during-pregnancy-live-birth" name="ValueSet - Infections During Pregnancy Live Birth"/>
-<artifact id="ValueSet/ValueSet-informant-relationship-to-mother" key="ValueSet-ValueSet-informant-relationship-to-mother" name="ValueSet - Informant Relationship to Mother"/>
-<artifact id="ValueSet/ValueSet-input-race-and-ethnicity-person-vr" key="ValueSet-ValueSet-input-race-and-ethnicity-person-vr" name="ValueSet - Input Race and Ethnicity Person Vital Records"/>
-<artifact id="ValueSet/ValueSet-jurisdiction-vr" key="ValueSet-ValueSet-jurisdiction-vr" name="ValueSet - Jurisdictions Vital Records"/>
-<artifact id="ValueSet/ValueSet-mother-relationship-vr" key="ValueSet-ValueSet-mother-relationship-vr" name="ValueSet - Mother Relationship Vital Records"/>
-<artifact id="ValueSet/ValueSet-mothers-date-of-birth-edit-flags" key="ValueSet-ValueSet-mothers-date-of-birth-edit-flags" name="ValueSet - Mothers Date of Birth Edit Flags (NCHS)"/>
-<artifact id="ValueSet/ValueSet-newborn-congenital-anomalies" key="ValueSet-ValueSet-newborn-congenital-anomalies" name="ValueSet - Newborn Congenital Anomalies"/>
-<artifact id="ValueSet/ValueSet-number-previous-cesareans-edit-flags" key="ValueSet-ValueSet-number-previous-cesareans-edit-flags" name="ValueSet - Number of Previous Cesareans Edit Flags (NCHS)"/>
-<artifact id="ValueSet/ValueSet-obstetric-procedure-outcome" key="ValueSet-ValueSet-obstetric-procedure-outcome" name="ValueSet - Obstetric Procedure Outcome"/>
-<artifact id="ValueSet/ValueSet-obstetric-procedure" key="ValueSet-ValueSet-obstetric-procedure" name="ValueSet - Obstetric Procedures"/>
-<artifact id="ValueSet/ValueSet-plurality-edit-flags" key="ValueSet-ValueSet-plurality-edit-flags" name="ValueSet - Plurality Edit Flags (NCHS)"/>
-<artifact id="ValueSet/ValueSet-pregnancy-report-edit-flags" key="ValueSet-ValueSet-pregnancy-report-edit-flags" name="ValueSet - Pregnancy Report Edit Flags (NCHS)"/>
-<artifact id="ValueSet/ValueSet-race-code-vr" key="ValueSet-ValueSet-race-code-vr" name="ValueSet - Race Code Vital Records"/>
-<artifact id="ValueSet/ValueSet-race-missing-value-reason-vr" key="ValueSet-ValueSet-race-missing-value-reason-vr" name="ValueSet - Race Missing Value Reason Vital Records"/>
-<artifact id="ValueSet/ValueSet-race-recode-40-vr" key="ValueSet-ValueSet-race-recode-40-vr" name="ValueSet - Race Recode 40 Vital Records"/>
-<artifact id="ValueSet/ValueSet-residence-country-vr" key="ValueSet-ValueSet-residence-country-vr" name="ValueSet - Residence Country Vital Records"/>
-<artifact id="ValueSet/ValueSet-states-territories-provinces-vr" key="ValueSet-ValueSet-states-territories-provinces-vr" name="ValueSet - States, Territories and Provinces Vital Records"/>
 <artifact id="ValueSet/ValueSet-tracking-number-type" key="ValueSet-ValueSet-tracking-number-type" name="ValueSet - Tracking Number Type"/>
-<artifact id="ValueSet/ValueSet-usstates-territories-vr" key="ValueSet-ValueSet-usstates-territories-vr" name="ValueSet - US States, Territories Vital Records"/>
-<artifact id="ValueSet/ValueSet-units-of-age-vr" key="ValueSet-ValueSet-units-of-age-vr" name="ValueSet - Units of Age Vital Records"/>
-<artifact id="ValueSet/ValueSet-yes-no-not-applicable-vr" key="ValueSet-ValueSet-yes-no-not-applicable-vr" name="ValueSet - Yes No Not Applicable Vital Records"/>
-<artifact id="ValueSet/ValueSet-yes-no-unknown-not-applicable-vr" key="ValueSet-ValueSet-yes-no-unknown-not-applicable-vr" name="ValueSet - Yes No Unknown NotApplicable Vital Records"/>
-<artifact id="ValueSet/ValueSet-yes-no-unknown-vr" key="ValueSet-ValueSet-yes-no-unknown-vr" name="ValueSet - Yes No Unknown Vital Records"/>
-<artifact id="Parameters/expansion-parameters-vr-common" key="Parameters-expansion-parameters-vr-common" name="expansion-parameters-vr-common"/>
 <page key="NA" name="(NA)"/>
 <page key="many" name="(many)"/>
 <page key="artifacts" name="Artifacts Summary"/>
-<page key="bfdr_appendices" name="BFDR Appendices"/>
-<page key="bfdr_change_log" name="BFDR Change Log"/>
-<page key="bfdr-content-transitions" name="BFDR Content Transitions"/>
-<page key="bfdr_ije_mapping_fetalDeath" name="BFDR Data Dictionary Fetal Death"/>
-<page key="bfdr_ije_mapping_natality" name="BFDR Data Dictionary Natality"/>
-<page key="bfdr_appendix_d_-_example_fetal_death_report" name="BFDR Example Fetal Death Report"/>
-<page key="bfdr_appendix_b_-_example_live_birth_certificate" name="BFDR Example Live Birth Certificate"/>
-<page key="bfdr_appendix_c_-_example_facility_worksheet_for_the_fetal_death_report" name="BFDR Facility Worksheet for Fetal Death"/>
-<page key="bfdr_appendix_a_-_example_facility_worksheet_for_the_live_birth_certificate" name="BFDR Facility Worksheet for Live Birth"/>
-<page key="bfdr_the_specification" name="BFDR Specification"/>
-<page key="bfdr_terminology" name="BFDR Terminology"/>
-<page key="bfdr_use_cases" name="BFDR Use Cases"/>
-<page key="bfdr_vital_records_form_mapping" name="BFDR Vital Records Form Mapping"/>
-<page key="bfdr_index" name="Birth and Fetal Death Reporting Home"/>
 <page key="index" name="Home"/>
 <page key="mdi_background" name="MDI Background"/>
 <page key="mdi_best_practices" name="MDI Best Practices"/>
@@ -648,13 +258,9 @@
 <page key="mdi_security_recommendations" name="MDI Security Recommendations"/>
 <page key="mdi_specification" name="MDI Specification"/>
 <page key="mdi_terminology" name="MDI Terminology"/>
-<page key="bfdr_patient_worksheet_questionnaires" name="Patient Worksheet Questionnaires"/>
 <page key="SurveillanceDataDictionary" name="Surveillance Data Dictionary"/>
 <page key="toc" name="Table of Contents"/>
 <page key="usage" name="Usage"/>
-<page key="vrcl_change_log" name="VRCL Change Log"/>
-<page key="vrcl_the_specification" name="VRCL Specification"/>
-<page key="vrcl_terminology" name="VRCL Terminology"/>
 <page key="vrdr_background" name="VRDR Background"/>
 <page key="vrdr_change_log" name="VRDR Change Log"/>
 <page key="vrdr_conformance" name="VRDR Conformance"/>
@@ -666,5 +272,4 @@
 <page key="vrdr_index" name="VRDR Home"/>
 <page key="vrdr_scope_of_the_vrdr_fhir_ig" name="VRDR Scope"/>
 <page key="vrdr_usage" name="VRDR Usage"/>
-<page key="vrcl_index" name="Vital Records Common Library Home"/>
 </specification>

--- a/input/pagecontent/mdi-content-transitions-old.md
+++ b/input/pagecontent/mdi-content-transitions-old.md
@@ -1,0 +1,45 @@
+# MDI to EDRS
+<!-- |Document MDI to EDRS (Bundle) |   Bundle |    -    | [] |     -         |   -      |
+|MDI to EDRS (Composition)|   Composition  |    -    | [] |     -         |   -      | -->
+
+| Name of Profile | Group | Change         |  Current Profile   | New Profile  | Comment |
+| :-------------: | ----- | -------------- | ------------- | ------------ | :-----: |
+|Decedent |  subject  |    using common VRCL profile   | [USCorePatient] |  [PatientVitalRecordsNew] |  [PatientVitalRecordsNew] is an abstract profile based on [USCorePatient] that includes additional slices  |
+|Medical Examiner/Coroner (Certifier) |  author, attester  |    using common VRCL profile, includes slice items within address and slices for qualification    | [USCorePractitioner] |  [PractitionerVitalRecordsNew]  |   -    |
+|Death Location |  circumstances  |    Removal of MS flags, inclusion of consolidated code system, inclusion of city and county extensions to accomodate VRDR, replacement of address text with state code - now uses harmonized VRDR profile     | [LocationDeath] | [DeathLocation] |  -  |
+|Tobacco Use Contributed to Death |  circumstances  | Removal of MS flags, inclusion of common value set - now uses harmonized VRDR profile w  | [ObservationTobaccoUseContributedToDeath] |    [TobaccoUseContributedToDeathNew] | - |
+|Decedent Pregnancy |  circumstances  |   Removal of MS flags, inclusion of consolidated value set to include missing value, inclusion of bypass edit flag extensions  - now uses harmonized VRDR profile | [ObservationDecedentPregnancy] | [DecedentPregnancyStatusNew] | - |
+|Injury Location |  circumstances  |    Removal of MS flags, inclusion of consolidated code system, inclusion of city and county extensions to accomodate VRDR, replacement of address text with state code  - now uses harmonized VRDR profile    | [LocationInjury] | [InjuryLocation] |  -  |
+|Death Date |  jurisdiction  |   Removal of MS flags, inclusion of consolidated partial date time extension, inclusion of consolidated value sets for place of death and date establishment approach, components for place and time of death are limited to one value  | [ObservationDeathDate] |  [DeathDateNew]  |   -      |
+|Death Certification |  jurisdiction  |    Removal of MS flags, inclusion of consolidated value set for certifier types  - now uses harmonized VRDR profile | [ProcedureDeathCertification] | [DeathCertificationNew] |  - |
+|Cause of Death Part 1 |  cause-manner  |  Removal of MS flags, removed performer cardinality, Cause of Death Part 1, Line a,b,c,d text is no longer part of a slice definition (just codeable concept)  | [ObservationCauseOfDeathPart1] | [CauseOfDeathPart1New] |   performer cardinality in MDI is 1..1, removal of cardinality prompts inheritance of 0..1 from observation profile  |
+|Cause of Death Part 2 |   cause-manner  |   Removal of MS flags - now uses harmonized VRDR profile   | [ObservationContributingCauseOfDeathPart2] | [CauseOfDeathPart2New] | - |
+|Manner of Death |  cause-manner  |   Removal of MS flags, performer cardinality relaxed to 0..* (observation default) - now uses harmonized VRDR profile  | [ObservationMannerOfDeath] | [MannerOfDeathNew] |   -      |
+|How Death Injury Occurred | cause-manner |  Removal of MS flags, performer cardinality relaxed to 0..* (observation default), inclusion of common partial date time extension, inclusion of common yes, no, unknown, not applicable value set for work injury indicator, inclusion of common transportation incident value set - now uses harmonized VRDR profile  | [ObservationHowDeathInjuryOccurred] | [InjuryIncidentNew]  | - |
+| Coded medical conditions | medical-history  |    -    | [USCoreConditionEncounterDiagnosis] or [USCoreConditionProblemsandHealthConcerns] |    -    |   not creating a new common profile   |
+|Autopsy Performed Indicator | exam-autopsy  |    -    | [ObservationAutopsyPerformedIndicator] |    -    |   profile with same/similar name is dissimilar across other profiles   |
+|Autopsy Location | exam-autopsy  |    -    | [USCoreOrganization] or [USCoreLocation] |    -    |   not creating a new common profile   |
+{: .grid }
+
+# Toxicology to MDI
+<!-- |Message Toxicology to MDI Bundle | Bundle |    -    | [] |     -         |   -      |
+|Toxicology to MDI MessageHeader | ToxtoMDIMessage |    -    | [] |     -         |   -      |
+|Toxicology Lab Result to MDI | DiagnosticReport |    -    | [] |     -         |   -      |  -->
+
+| Name of Profile | Group | Change         |  Current Profile   | New Profile  | Comment |
+| :-------------: | ----- | -------------- | ------------- | ------------ | :-----: | 
+|Performer |  performer  |  - | [USCorePractitioner] or [USCorePractitionerRole] | - |   not creating a new common profile  |
+|Decedent |  subject  |    -    | [USCorePatient] |  -  |   not creating a new common profile   |
+|Toxicology Lab Specimen |  specimen  |    -    | [SpecimenToxicologyLab] |     -         |   -      |
+|Toxicology Lab Result | result  |    -    | [ObservationToxicologyLabResult] |     -         |   -      |
+{: .grid }
+
+<!-- # Administrative / Other
+| Name of Profile | Group | change  |  Current Profile   | New Profile  | Comment |
+| :-------------: | ----- | ------- | ------------------ | ------------ | :-----: | 
+|Document Reference: MDI Report | Administrative Profiles  |    -    | [] |     -         |   -      |
+|MessageDefinitionToxicologySystem  | Capability Statements  |    -    | [MessageDefinition-toxicology-system] |     -         |   -      |
+{: .grid } -->
+
+
+{% include markdown-link-references.md %}

--- a/input/pagecontent/mdi-content-transitions.md
+++ b/input/pagecontent/mdi-content-transitions.md
@@ -43,6 +43,7 @@
 <tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Observation-toxicology-lab-result.html'>ObservationToxicologyLabResult</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-toxicology-lab-result.html'>MDI</a> </td><td>-</td></tr>
 <tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Specimen-toxicology-lab.html'>SpecimenToxicologyLab</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Specimen-toxicology-lab.html'>MDI</a> </td><td>-</td></tr>
 <tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/MessageDefinition-MessageDefinition-toxicology-system.html'>MessageDefinitionToxicologySystem</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/MessageDefinition-MessageDefinition-toxicology-system.html'>MDI</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-DocumentReference-mdi-reportm.html'>DocumentReferenceMDIReport</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-DocumentReference-mdi-report.html'>MDI</a> </td><td> _________ </td></tr>
 </tbody>
 </table>
 
@@ -109,7 +110,6 @@
 <tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Procedure-death-certification.html'>ProcedureDeathCertification</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-certification'>VRDR</a> </td><td>-</td></tr>
 <tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Location-death.html'>LocationDeath</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-location'>VRDR</a> </td><td>-</td></tr>
 <tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Location-injury.html'>LocationInjury</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-manner-of-death'>VRDR</a> </td><td>-</td></tr>
-<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-DocumentReference-mdi-report.html'>DocumentReferenceMDIReport</a> </td><td>Removed</td><td>-</td></tr>
 </tbody>
 </table>
 

--- a/input/pagecontent/mdi-content-transitions.md
+++ b/input/pagecontent/mdi-content-transitions.md
@@ -1,45 +1,166 @@
-# MDI to EDRS
-<!-- |Document MDI to EDRS (Bundle) |   Bundle |    -    | [] |     -         |   -      |
-|MDI to EDRS (Composition)|   Composition  |    -    | [] |     -         |   -      | -->
+<style>
+    table.style1 { 
+        border-collapse: collapse; 
+        width: 100%; 
+        table-layout: fixed;
+    }  
+    table.style1 tbody tr {
+        border-bottom: 1px solid #dddddd;
+    } 
+    table.style1 tbody tr:nth-of-type(even) { 
+        background-color: #f3f3f3; 
+    } 
+    table.style1 tbody tr:last-of-type {
+        border-bottom: 2px solid #98c1d9;
+    }
+    table.style1 td:first-of-type {
+        text-align: left;
+    }
+    table.style1 td:nth-of-type(2) {
+        text-align: center;
+    }
+    table.style1 td:nth-of-type(3) {
+        text-align: left;
+    }
+</style>
+{% include transitions_documentation.md %}
+<br/><br/>
 
-| Name of Profile | Group | Change         |  Current Profile   | New Profile  | Comment |
-| :-------------: | ----- | -------------- | ------------- | ------------ | :-----: |
-|Decedent |  subject  |    using common VRCL profile   | [USCorePatient] |  [PatientVitalRecordsNew] |  [PatientVitalRecordsNew] is an abstract profile based on [USCorePatient] that includes additional slices  |
-|Medical Examiner/Coroner (Certifier) |  author, attester  |    using common VRCL profile, includes slice items within address and slices for qualification    | [USCorePractitioner] |  [PractitionerVitalRecordsNew]  |   -    |
-|Death Location |  circumstances  |    Removal of MS flags, inclusion of consolidated code system, inclusion of city and county extensions to accomodate VRDR, replacement of address text with state code - now uses harmonized VRDR profile     | [LocationDeath] | [DeathLocation] |  -  |
-|Tobacco Use Contributed to Death |  circumstances  | Removal of MS flags, inclusion of common value set - now uses harmonized VRDR profile w  | [ObservationTobaccoUseContributedToDeath] |    [TobaccoUseContributedToDeathNew] | - |
-|Decedent Pregnancy |  circumstances  |   Removal of MS flags, inclusion of consolidated value set to include missing value, inclusion of bypass edit flag extensions  - now uses harmonized VRDR profile | [ObservationDecedentPregnancy] | [DecedentPregnancyStatusNew] | - |
-|Injury Location |  circumstances  |    Removal of MS flags, inclusion of consolidated code system, inclusion of city and county extensions to accomodate VRDR, replacement of address text with state code  - now uses harmonized VRDR profile    | [LocationInjury] | [InjuryLocation] |  -  |
-|Death Date |  jurisdiction  |   Removal of MS flags, inclusion of consolidated partial date time extension, inclusion of consolidated value sets for place of death and date establishment approach, components for place and time of death are limited to one value  | [ObservationDeathDate] |  [DeathDateNew]  |   -      |
-|Death Certification |  jurisdiction  |    Removal of MS flags, inclusion of consolidated value set for certifier types  - now uses harmonized VRDR profile | [ProcedureDeathCertification] | [DeathCertificationNew] |  - |
-|Cause of Death Part 1 |  cause-manner  |  Removal of MS flags, removed performer cardinality, Cause of Death Part 1, Line a,b,c,d text is no longer part of a slice definition (just codeable concept)  | [ObservationCauseOfDeathPart1] | [CauseOfDeathPart1New] |   performer cardinality in MDI is 1..1, removal of cardinality prompts inheritance of 0..1 from observation profile  |
-|Cause of Death Part 2 |   cause-manner  |   Removal of MS flags - now uses harmonized VRDR profile   | [ObservationContributingCauseOfDeathPart2] | [CauseOfDeathPart2New] | - |
-|Manner of Death |  cause-manner  |   Removal of MS flags, performer cardinality relaxed to 0..* (observation default) - now uses harmonized VRDR profile  | [ObservationMannerOfDeath] | [MannerOfDeathNew] |   -      |
-|How Death Injury Occurred | cause-manner |  Removal of MS flags, performer cardinality relaxed to 0..* (observation default), inclusion of common partial date time extension, inclusion of common yes, no, unknown, not applicable value set for work injury indicator, inclusion of common transportation incident value set - now uses harmonized VRDR profile  | [ObservationHowDeathInjuryOccurred] | [InjuryIncidentNew]  | - |
-| Coded medical conditions | medical-history  |    -    | [USCoreConditionEncounterDiagnosis] or [USCoreConditionProblemsandHealthConcerns] |    -    |   not creating a new common profile   |
-|Autopsy Performed Indicator | exam-autopsy  |    -    | [ObservationAutopsyPerformedIndicator] |    -    |   profile with same/similar name is dissimilar across other profiles   |
-|Autopsy Location | exam-autopsy  |    -    | [USCoreOrganization] or [USCoreLocation] |    -    |   not creating a new common profile   |
-{: .grid }
+### STU2 Profiles
 
-# Toxicology to MDI
-<!-- |Message Toxicology to MDI Bundle | Bundle |    -    | [] |     -         |   -      |
-|Toxicology to MDI MessageHeader | ToxtoMDIMessage |    -    | [] |     -         |   -      |
-|Toxicology Lab Result to MDI | DiagnosticReport |    -    | [] |     -         |   -      |  -->
-
-| Name of Profile | Group | Change         |  Current Profile   | New Profile  | Comment |
-| :-------------: | ----- | -------------- | ------------- | ------------ | :-----: | 
-|Performer |  performer  |  - | [USCorePractitioner] or [USCorePractitionerRole] | - |   not creating a new common profile  |
-|Decedent |  subject  |    -    | [USCorePatient] |  -  |   not creating a new common profile   |
-|Toxicology Lab Specimen |  specimen  |    -    | [SpecimenToxicologyLab] |     -         |   -      |
-|Toxicology Lab Result | result  |    -    | [ObservationToxicologyLabResult] |     -         |   -      |
-{: .grid }
-
-<!-- # Administrative / Other
-| Name of Profile | Group | change  |  Current Profile   | New Profile  | Comment |
-| :-------------: | ----- | ------- | ------------------ | ------------ | :-----: | 
-|Document Reference: MDI Report | Administrative Profiles  |    -    | [] |     -         |   -      |
-|MessageDefinitionToxicologySystem  | Capability Statements  |    -    | [MessageDefinition-toxicology-system] |     -         |   -      |
-{: .grid } -->
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Previous Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Bundle-document-mdi-to-edrs.html'>BundleDocumentMDIToEDRS</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Bundle-document-mdi-and-edrs.html'>MDI</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Bundle-message-tox-to-mdi.html'>BundleMessageToxToMDI</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Bundle-message-tox-to-mdi.html'>MDI</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Composition-mdi-to-edrs.html'>CompositionMDIToEDRS</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Composition-mdi-and-edrs.html'>MDI</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-DiagnosticReport-toxicology-to-mdi.html'>DiagnosticReportToxicologyToMDI</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-DiagnosticReport-toxicology-to-mdi.html'>MDI</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-MessageHeader-toxicology-to-mdi.html'>MessageHeaderToxicologyToMDI</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-MessageHeader-toxicology-to-mdi.html'>MDI</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Observation-toxicology-lab-result.html'>ObservationToxicologyLabResult</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-toxicology-lab-result.html'>MDI</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Specimen-toxicology-lab.html'>SpecimenToxicologyLab</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Specimen-toxicology-lab.html'>MDI</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/MessageDefinition-MessageDefinition-toxicology-system.html'>MessageDefinitionToxicologySystem</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/MessageDefinition-MessageDefinition-toxicology-system.html'>MDI</a> </td><td>-</td></tr>
+</tbody>
+</table>
 
 
-{% include markdown-link-references.md %}
+### STU2 Extensions
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Previous Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Extension-tracking-number.html'>ExtensionTrackingNumber</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Extension-tracking-number.html'>MDI</a> </td><td>-</td></tr>
+</tbody>
+</table>
+
+
+### STU2 Valuesets
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Previous Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-ValueSet-tracking-number-type.html'>ValueSetTrackingNumberType</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/ValueSet-ValueSet-tracking-number-type.html'>MDI</a> </td><td>-</td></tr>
+</tbody>
+</table>
+
+
+### STU2 Codesystems
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Previous Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-CodeSystem-vr-codes.html'>CodeSystemMDI</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/CodeSystem-CodeSystem-mdi-codes.html'>MDI</a> </td><td>-</td></tr>
+</tbody>
+</table>
+
+
+### Removed Profiles
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Current Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-cause-of-death-part1.html'>ObservationCauseOfDeathPart1</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-cause-of-death-part1'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-contributing-cause-of-death-part2.html'>ObservationContributingCauseOfDeathPart2</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-cause-of-death-part2'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-death-date.html'>ObservationDeathDate</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-date'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-how-death-injury-occurred.html'>ObservationHowDeathInjuryOccurred</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-injury-incident'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-manner-of-death.html'>ObservationMannerOfDeath</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-manner-of-death'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-decedent-pregnancy.html'>ObservationDecedentPregnancy</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent-pregnancy-status'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-tobacco-use-contributed-to-death.html'>ObservationTobaccoUseContributedToDeath</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-contributory-tobacco-use-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-autopsy-performed-indicator.html'>ObservationAutopsyPerformedIndicator</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-autopsy-performed-indicator'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Procedure-death-certification.html'>ProcedureDeathCertification</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-certification'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Location-death.html'>LocationDeath</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-location'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Location-injury.html'>LocationInjury</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-manner-of-death'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-DocumentReference-mdi-report.html'>DocumentReferenceMDIReport</a> </td><td>Removed</td><td>-</td></tr>
+</tbody>
+</table>
+
+
+### Removed Extensions
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Current Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> n/a</td><td>n/a</td><td> n/a </td></tr>
+</tbody>
+</table>
+
+
+### Removed Valuesets
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Current Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/ValueSet/ValueSet-certifier-types'>ValueSetCertifierTypes</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-certifier-types-vs'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/ValueSet/ValueSet-contributory-tobacco-use'>ValueSetContributoryTobaccoUse</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-contributory-tobacco-use-vs'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/ValueSet/ValueSet-date-establishment-approach'>ValueSetDateEstablishmentApproach</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-date-of-death-determination-methods-vs'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/ValueSet/ValueSet-death-pregnancy-status'>ValueSetDeathPregnancyStatus</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-ValueSet-death-pregnancy-status'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/ValueSet/ValueSet-manner-of-death'>ValueSetMannerOfDeath</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-manner-of-death-vs'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/ValueSet-ValueSet-place-of-death.html'>ValueSetPlaceOfDeath</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-place-of-death-vs'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/STU1.1/ValueSet-ValueSet-transportation-incident-role.html'>ValueSetTransportationIncidentRole</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-transportation-incident-role-vs'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/ValueSet/ValueSet-yes-no-unknown'>ValueSetYesNoUnknown</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-yes-no-unknown-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/ValueSet/ValueSet-yes-no-unknown-not-applicable'>ValueSetYesNoUnknownNotApplicable</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-yes-no-not-applicable-vr.html'>VRCL</a> </td><td>-</td></tr>
+</tbody>
+</table>
+
+
+### Removed Codesystems
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Current Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/CodeSystem/CodeSystem-death-pregnancy-status'>CodeSystemDeathPregnancyStatus</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-CodeSystem-death-pregnancy-status'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/mdi/CodeSystem/CodeSystem-local-component-codes'>CodeSystemLocalComponentCodes</a> </td><td><a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-component-cs'>VRDR</a> </td><td>-</td></tr>
+</tbody>
+</table>
+

--- a/input/pagecontent/mdi-content-transitions.md
+++ b/input/pagecontent/mdi-content-transitions.md
@@ -43,7 +43,7 @@
 <tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Observation-toxicology-lab-result.html'>ObservationToxicologyLabResult</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Observation-toxicology-lab-result.html'>MDI</a> </td><td>-</td></tr>
 <tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Specimen-toxicology-lab.html'>SpecimenToxicologyLab</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-Specimen-toxicology-lab.html'>MDI</a> </td><td>-</td></tr>
 <tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/MessageDefinition-MessageDefinition-toxicology-system.html'>MessageDefinitionToxicologySystem</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/MessageDefinition-MessageDefinition-toxicology-system.html'>MDI</a> </td><td>-</td></tr>
-<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-DocumentReference-mdi-reportm.html'>DocumentReferenceMDIReport</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-DocumentReference-mdi-report.html'>MDI</a> </td><td> _________ </td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-DocumentReference-mdi-reportm.html'>DocumentReferenceMDIReport</a> </td><td><a href='http://hl7.org/fhir/us/mdi/STU1.1/StructureDefinition-DocumentReference-mdi-report.html'>MDI</a> </td><td>-</td></tr>
 </tbody>
 </table>
 

--- a/input/pagecontent/transitions_documentation.md
+++ b/input/pagecontent/transitions_documentation.md
@@ -1,0 +1,12 @@
+
+### Note
+
+Below are descriptions for each of the headers found in the transition tables. The tables are meant to describe changes to resources and their movements between IGs.
+
+| **Field Name** | **Description** |
+| :-----------: | :-----------: |
+| Name | Name of the resource (past or present) |
+| Previous Version/Location | Previous location of resource (links to past version) |
+| Current Version/Location | Current location of resource (links to current version) |
+| Comments/Updates  | Description of changes specific to the resource | 
+{: .grid }

--- a/input/pagecontent/vrdr-content-transitions-old.md
+++ b/input/pagecontent/vrdr-content-transitions-old.md
@@ -1,0 +1,77 @@
+# Death Record Submission
+
+
+
+| Name of Profile  | Group | change  |  Current Profile   | New Profile  | Comment |
+| ------------- | ----- | ------- | ------------------ | ------------ | ----- | 
+|Death Certificate |   -  |    -    | [DeathCertificate] |     [DeathCertificateNew]         |   Updated to reference generalized profiles and valuesets in VRCL      |
+|Decedent |   DecedentDemographics  |    -    | [Decedent] |       [DecedentNew]       |    Update partial dates and references, now based on [PatientVitalRecordsNew]     |
+|Father |     DecedentDemographics    |    -    | [DecedentFather] |       -       |    -     |
+|Mother |     DecedentDemographics    |    -    | [DecedentMother] |       -       |    -     |
+|Spouse |     DecedentDemographics    |    -    | [DecedentSpouse] |       -       |    -     |
+|Age at Death |     DecedentDemographics    |    -    | [DecedentAge] |       -       |    -     |
+|BirthRecord ID |     DecedentDemographics    |    -    | [BirthRecordIdentifier] |       -       |    -     |
+|Education Level |     DecedentDemographics    |    now based on [ObservationEducationLevelVitalRecordsNew] in VRCL     | [DecedentEducationLevel] |       -     |    -     |
+|Military Service |    DecedentDemographics    |    -    | [DecedentMilitaryService] |       -       |    -     |
+|Usual Work |     DecedentDemographics   |    -    | [DecedentUsualWork] |       -       |    -     |
+| Emerging Issues |     DecedentDemographics   |    -    | [EmergingIssues] |       -       |    -     |
+| Input Race and Ethnicity |     DecedentDemographics    |    -    | [InputRaceAndEthnicity] |       [InputRaceAndEthnicityNew]       |    -     |
+| Examiner Contacted |     DeathInvestigation    |    -    | [ExaminerContacted] |       -       |    -     |
+|Pregnancy Status |     DeathInvestigation    |    updated subject and VS    | [DecedentPregnancyStatus] |       [DecedentPregnancyStatusNew]       |    -     |
+|Tobacco Use |     DeathInvestigation    |    updated subject (although they match exactly here)    | [TobaccoUseContributedToDeath] |       [TobaccoUseContributedToDeathNew]       |    -     |
+|Death Location |     DeathInvestigation   |    -    | [DeathLocation] |       -       |    -     |
+|Injury Location |     DeathInvestigation   |    -    | [InjuryLocation] |     -    |    -     |
+|Injury Incident |     DeathInvestigation   |    constrained performer to [USCorePractitioner], updated value sets   | [InjuryIncident] |       [InjuryIncidentNew]       |    -     |
+|Autopsy Performed Indicator|     DeathInvestigation   |    -    | [AutopsyPerformedIndicator] |       -       |    -     |
+|Death Date |     DeathInvestigation   |    updated value sets, subject updated to [PatientVitalRecordsNew], performer constrained to [USCorePractitioner]   | [DeathDate] |       [DeathDateNew]       |    -     |
+|Surgery Date |     DeathInvestigation   |    -    | [SurgeryDate] |       -       |    -     |
+|Certifier |     DeathCertification   |    added birthAttendantQualification    | [Certifier] |       [PractitionerVitalRecordsNew]      |    -     |
+|Death Certification |     DeathCertification   |    removed deprecated category and replaced Certifier with [PractitionerVitalRecordsNew]    | [DeathCertification] |       [DeathCertificationNew]       |    -     |
+|Manner Of Death |     DeathInvestigation   |    replaced Certifier with [USCorePractitioner] and Decedent with [PatientVitalRecordsNew]  | [MannerOfDeath] |       [MannerOfDeathNew]       |    -     |
+|Cause Of Death Part1 |     DeathInvestigation   |    added UnitsOfAgeVS, replaced Certifier with [USCorePractitioner] and Decedent with [PatientVitalRecordsNew]   | [CauseOfDeathPart1] |  [CauseOfDeathPart1New]            |    -     |
+|Cause Of Death Part2 |     DeathInvestigation   |    replaced Certifier with [USCorePractitioner] and Decedent with [PatientVitalRecordsNew]    | [CauseOfDeathPart2] |   [CauseOfDeathPart2New]           |    -     |
+|Disposition Method |     DecedentDisposition   |    subject is now [PatientVitalRecordsNew] (old profile was also updated here)   | [DecedentDispositionMethod] |    [DecedentDispositionMethodNew]   |    -     |
+|Disposition Location |     DecedentDisposition   |    -    | [DispositionLocation] |       |   Base on Consolidated Vital Records Location (with death, injury)?     |
+|FuneralHome |     DecedentDisposition   |    -    | [FuneralHome] |        -      |    -     |
+|Mortician |     DecedentDisposition   |    -    | [USCorePractitioner] |       -       |    -     |
+{: .grid }
+
+
+| Name of Extension  | change  |  Current Extension   | New Extension  | Comment |
+| ------------------ | ------- | ------------------ | ------------ | ----- | 
+|Partial Date  |    -    | [PartialDate] |    [ExtensionDatePartAbsentReasonVitalRecords]         |   -      |
+|Partial Date Time  |    -    | [PartialDateTime] | [ExtensionPartialDateTimeVitalRecords]             |    -     |
+{: .grid }
+
+# Coded Cause of Death
+
+| Name of Profile  | Group | change  |  Current Profile   | New Profile  | Comment |
+| ------------- | ----- | ------- | ------------------ | ------------ | ----- | 
+|ActivityAt Time Of Death|     CodedContent   |    -    | [ActivityAtTimeOfDeath] |       -       |    -     |
+|Automated Underlying Cause Of Death |     CodedContent   |    -    | [AutomatedUnderlyingCauseOfDeath] |       -       |    -     |
+|ManualUnderlyingCauseOfDeath |     CodedContent   |    -    | [ManualUnderlyingCauseOfDeath] |       -       |    -     |
+|EntityAxisCauseOfDeath |     CodedContent   |    -    | [EntityAxisCauseOfDeath] |       -       |    -     |
+|RecordAxisCauseOfDeath |     CodedContent   |    -    | [RecordAxisCauseOfDeath] |       -       |    -     |
+|PlaceOfInjury |     CodedContent   |    -    | [PlaceOfInjury] |       -       |    -     |
+|CodingStatusValues |     CodedContent   |    -    | [CodingStatusValues] |       -       |    -     |
+|Cause Of Death Part1 |     InputContent   |    see above    | [CauseOfDeathPart1] |  [CauseOfDeathPart1New]            |    -     |
+|Cause Of Death Part2 |     InputContent   |    see above    | [CauseOfDeathPart2] |   [CauseOfDeathPart2New]           |    -     |
+|Manner Of Death |     InputContent   |    see above    | [MannerOfDeath] |       [MannerOfDeathNew]       |    -     |
+|Autopsy Performed Indicator|     InputContent   |    -    | [AutopsyPerformedIndicator] |       -       |    -     |
+|Death Certification |     InputContent   |    see above    | [DeathCertification] |       [DeathCertificationNew]       |    -     |
+|Injury Incident |     InputContent   |    see above   | [InjuryIncident] |       [InjuryIncidentNew]       |    -     |
+|Tobacco Use |     InputContent    |    see above    | [TobaccoUseContributedToDeath] |       [TobaccoUseContributedToDeathNew]       |    -     |
+|Pregnancy Status |     InputContent    |    see above    | [DecedentPregnancyStatus] |       [DecedentPregnancyStatusNew]       |    -     |
+|Surgery Date |     InputContent   |    -    | [SurgeryDate] |       -       |    -     |
+{: .grid }
+
+# Coded Race and Ethnicity
+
+| Name of Profile  | Group | change  |  Current Profile   | New Profile  | Comment |
+| ------------- | ----- | ------- | ------------------ | ------------ | ----- | 
+| CodedRaceAndEthnicity |     CodedContent   |    -    | [CodedRaceAndEthnicity] |      [CodedRaceAndEthnicityNew]       |    -     |
+| Input Race and Ethnicity |     InputContent    |    -    | [InputRaceAndEthnicity] |       [InputRaceAndEthnicityNew]       |    -     |
+{: .grid }
+
+
+{% include markdown-link-references.md %}

--- a/input/pagecontent/vrdr-content-transitions.md
+++ b/input/pagecontent/vrdr-content-transitions.md
@@ -1,77 +1,257 @@
-# Death Record Submission
+<style>
+    table.style1 { 
+        border-collapse: collapse; 
+        width: 100%; 
+        table-layout: fixed;
+    }  
+    table.style1 tbody tr {
+        border-bottom: 1px solid #dddddd;
+    } 
+    table.style1 tbody tr:nth-of-type(even) { 
+        background-color: #f3f3f3; 
+    } 
+    table.style1 tbody tr:last-of-type {
+        border-bottom: 2px solid #98c1d9;
+    }
+    table.style1 td:first-of-type {
+        text-align: left;
+    }
+    table.style1 td:nth-of-type(2) {
+        text-align: center;
+    }
+    table.style1 td:nth-of-type(3) {
+        text-align: left;
+    }
+</style>
+{% include transitions_documentation.md %}
+<br/><br/>
+
+### STU3 Profiles
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Previous Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-activity-at-time-of-death'>ActivityAtTimeOfDeath</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-activity-at-time-of-death.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-automated-underlying-cause-of-death'>AutomatedUnderlyingCauseOfDeath</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-automated-underlying-cause-of-death'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-autopsy-performed-indicator'>AutopsyPerformedIndicator</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-autopsy-performed-indicator.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-birth-record-identifier'>BirthRecordIdentifier</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-birth-record-identifier.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-cause-of-death-coded-bundle'>CauseOfDeathCodedContentBundle</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-cause-of-death-coded-bundle.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-cause-of-death-part1'>CauseOfDeathPart1</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-cause-of-death-part1.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-cause-of-death-part2'>CauseOfDeathPart2</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-cause-of-death-part2.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-certifier.html'>Certifier</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-certifier.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-coding-status-values.html'>CodingStatusValues</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-coding-status-values.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-certificate.html'>DeathCertificate</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-death-certificate.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-certificate-document'>DeathCertificateDocument</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-death-certificate-document.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-certification.html'>DeathCertification</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-death-certification.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-location'>DeathLocation</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-death-location.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent.html'>Decedent</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent-age'>DecedentAge</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent-age.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent-disposition-method'>DecedentDispositionMethod</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent-disposition-method.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent-education-level'>DecedentEducationLevel</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent-education-level.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent-father.html'>DecedentFather</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent-father.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent-military-service.html'>DecedentMilitaryService</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent-military-service.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent-mother'>DecedentMother</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent-mother.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent-spouse.html'>DecedentSpouse</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent-spouse.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-demographic-coded-bundle.html'>DemographicCodedContentBundle</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-demographic-coded-bundle.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-disposition-location.html'>DispositionLocation</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-disposition-location.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-entity-axis-cause-of-death.html'>EntityAxisCauseOfDeath</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-entity-axis-cause-of-death.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-examiner-contacted.html'>ExaminerContacted</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-examiner-contacted.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-funeral-home.html'>FuneralHome</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-funeral-home.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-injury-location'>InjuryLocation</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-injury-location.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-manner-of-death.html'>MannerOfDeath</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-manner-of-death.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-manual-underlying-cause-of-death.html'>ManualUnderlyingCauseOfDeath</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-manual-underlying-cause-of-death.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-mortality-roster-bundle.html'>MortalityRosterBundle</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-mortality-roster-bundle.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-death-date.html'>DeathDate</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-death-date.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-decedent-pregnancy-status.html'>DecedentPregnancyStatus</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent-pregnancy-status.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-injury-incident.html'>InjuryIncident</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-injury-incident.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-place-of-injury.html'>PlaceOfInjury</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-place-of-injury.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-record-axis-cause-of-death.html'>RecordAxisCauseOfDeath</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-record-axis-cause-of-death.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-surgery-date.html'>SurgeryDate</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-surgery-date.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-vrdr-tobacco-use-contributed-to-death.html'>TobaccoUseContributedToDeath</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-tobacco-use-contributed-to-death.html'>VRDR</a> </td><td>-</td></tr>
+</tbody>
+</table>
 
 
+### STU3 Extensions
 
-| Name of Profile  | Group | change  |  Current Profile   | New Profile  | Comment |
-| ------------- | ----- | ------- | ------------------ | ------------ | ----- | 
-|Death Certificate |   -  |    -    | [DeathCertificate] |     [DeathCertificateNew]         |   Updated to reference generalized profiles and valuesets in VRCL      |
-|Decedent |   DecedentDemographics  |    -    | [Decedent] |       [DecedentNew]       |    Update partial dates and references, now based on [PatientVitalRecordsNew]     |
-|Father |     DecedentDemographics    |    -    | [DecedentFather] |       -       |    -     |
-|Mother |     DecedentDemographics    |    -    | [DecedentMother] |       -       |    -     |
-|Spouse |     DecedentDemographics    |    -    | [DecedentSpouse] |       -       |    -     |
-|Age at Death |     DecedentDemographics    |    -    | [DecedentAge] |       -       |    -     |
-|BirthRecord ID |     DecedentDemographics    |    -    | [BirthRecordIdentifier] |       -       |    -     |
-|Education Level |     DecedentDemographics    |    now based on [ObservationEducationLevelVitalRecordsNew] in VRCL     | [DecedentEducationLevel] |       -     |    -     |
-|Military Service |    DecedentDemographics    |    -    | [DecedentMilitaryService] |       -       |    -     |
-|Usual Work |     DecedentDemographics   |    -    | [DecedentUsualWork] |       -       |    -     |
-| Emerging Issues |     DecedentDemographics   |    -    | [EmergingIssues] |       -       |    -     |
-| Input Race and Ethnicity |     DecedentDemographics    |    -    | [InputRaceAndEthnicity] |       [InputRaceAndEthnicityNew]       |    -     |
-| Examiner Contacted |     DeathInvestigation    |    -    | [ExaminerContacted] |       -       |    -     |
-|Pregnancy Status |     DeathInvestigation    |    updated subject and VS    | [DecedentPregnancyStatus] |       [DecedentPregnancyStatusNew]       |    -     |
-|Tobacco Use |     DeathInvestigation    |    updated subject (although they match exactly here)    | [TobaccoUseContributedToDeath] |       [TobaccoUseContributedToDeathNew]       |    -     |
-|Death Location |     DeathInvestigation   |    -    | [DeathLocation] |       -       |    -     |
-|Injury Location |     DeathInvestigation   |    -    | [InjuryLocation] |     -    |    -     |
-|Injury Incident |     DeathInvestigation   |    constrained performer to [USCorePractitioner], updated value sets   | [InjuryIncident] |       [InjuryIncidentNew]       |    -     |
-|Autopsy Performed Indicator|     DeathInvestigation   |    -    | [AutopsyPerformedIndicator] |       -       |    -     |
-|Death Date |     DeathInvestigation   |    updated value sets, subject updated to [PatientVitalRecordsNew], performer constrained to [USCorePractitioner]   | [DeathDate] |       [DeathDateNew]       |    -     |
-|Surgery Date |     DeathInvestigation   |    -    | [SurgeryDate] |       -       |    -     |
-|Certifier |     DeathCertification   |    added birthAttendantQualification    | [Certifier] |       [PractitionerVitalRecordsNew]      |    -     |
-|Death Certification |     DeathCertification   |    removed deprecated category and replaced Certifier with [PractitionerVitalRecordsNew]    | [DeathCertification] |       [DeathCertificationNew]       |    -     |
-|Manner Of Death |     DeathInvestigation   |    replaced Certifier with [USCorePractitioner] and Decedent with [PatientVitalRecordsNew]  | [MannerOfDeath] |       [MannerOfDeathNew]       |    -     |
-|Cause Of Death Part1 |     DeathInvestigation   |    added UnitsOfAgeVS, replaced Certifier with [USCorePractitioner] and Decedent with [PatientVitalRecordsNew]   | [CauseOfDeathPart1] |  [CauseOfDeathPart1New]            |    -     |
-|Cause Of Death Part2 |     DeathInvestigation   |    replaced Certifier with [USCorePractitioner] and Decedent with [PatientVitalRecordsNew]    | [CauseOfDeathPart2] |   [CauseOfDeathPart2New]           |    -     |
-|Disposition Method |     DecedentDisposition   |    subject is now [PatientVitalRecordsNew] (old profile was also updated here)   | [DecedentDispositionMethod] |    [DecedentDispositionMethodNew]   |    -     |
-|Disposition Location |     DecedentDisposition   |    -    | [DispositionLocation] |       |   Base on Consolidated Vital Records Location (with death, injury)?     |
-|FuneralHome |     DecedentDisposition   |    -    | [FuneralHome] |        -      |    -     |
-|Mortician |     DecedentDisposition   |    -    | [USCorePractitioner] |       -       |    -     |
-{: .grid }
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Previous Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-AliasStatus.html'>AliasStatus</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-AliasStatus.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-AuxiliaryStateIdentifier1.html'>AuxiliaryStateIdentifier1</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-AuxiliaryStateIdentifier1.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-AuxiliaryStateIdentifier2.html'>AuxiliaryStateIdentifier2</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-AuxiliaryStateIdentifier2.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-CertificateNumber.html'>CertificateNumber</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-CertificateNumber.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-FilingFormat.html'>FilingFormat</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-FilingFormat.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-Location-Jurisdiction-Id.html'>LocationJurisdictionId</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-Location-Jurisdiction-Id.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-NVSS-SexAtDeath.html'>NVSSSexAtDeath</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-NVSS-SexAtDeath.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-ReplaceStatus.html'>ReplaceStatus</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-ReplaceStatus.html'>VRDR</a> </td><td> Deprecated </td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-SpouseAlive.html'>SpouseAlive</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-SpouseAlive.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/StructureDefinition-StateSpecificField.html'>StateSpecificField</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-StateSpecificField.html'>VRDR</a> </td><td>-</td></tr>
+</tbody>
+</table>
 
 
-| Name of Extension  | change  |  Current Extension   | New Extension  | Comment |
-| ------------------ | ------- | ------------------ | ------------ | ----- | 
-|Partial Date  |    -    | [PartialDate] |    [ExtensionDatePartAbsentReasonVitalRecords]         |   -      |
-|Partial Date Time  |    -    | [PartialDateTime] | [ExtensionPartialDateTimeVitalRecords]             |    -     |
-{: .grid }
+### STU3 Valuesets
 
-# Coded Cause of Death
-
-| Name of Profile  | Group | change  |  Current Profile   | New Profile  | Comment |
-| ------------- | ----- | ------- | ------------------ | ------------ | ----- | 
-|ActivityAt Time Of Death|     CodedContent   |    -    | [ActivityAtTimeOfDeath] |       -       |    -     |
-|Automated Underlying Cause Of Death |     CodedContent   |    -    | [AutomatedUnderlyingCauseOfDeath] |       -       |    -     |
-|ManualUnderlyingCauseOfDeath |     CodedContent   |    -    | [ManualUnderlyingCauseOfDeath] |       -       |    -     |
-|EntityAxisCauseOfDeath |     CodedContent   |    -    | [EntityAxisCauseOfDeath] |       -       |    -     |
-|RecordAxisCauseOfDeath |     CodedContent   |    -    | [RecordAxisCauseOfDeath] |       -       |    -     |
-|PlaceOfInjury |     CodedContent   |    -    | [PlaceOfInjury] |       -       |    -     |
-|CodingStatusValues |     CodedContent   |    -    | [CodingStatusValues] |       -       |    -     |
-|Cause Of Death Part1 |     InputContent   |    see above    | [CauseOfDeathPart1] |  [CauseOfDeathPart1New]            |    -     |
-|Cause Of Death Part2 |     InputContent   |    see above    | [CauseOfDeathPart2] |   [CauseOfDeathPart2New]           |    -     |
-|Manner Of Death |     InputContent   |    see above    | [MannerOfDeath] |       [MannerOfDeathNew]       |    -     |
-|Autopsy Performed Indicator|     InputContent   |    -    | [AutopsyPerformedIndicator] |       -       |    -     |
-|Death Certification |     InputContent   |    see above    | [DeathCertification] |       [DeathCertificationNew]       |    -     |
-|Injury Incident |     InputContent   |    see above   | [InjuryIncident] |       [InjuryIncidentNew]       |    -     |
-|Tobacco Use |     InputContent    |    see above    | [TobaccoUseContributedToDeath] |       [TobaccoUseContributedToDeathNew]       |    -     |
-|Pregnancy Status |     InputContent    |    see above    | [DecedentPregnancyStatus] |       [DecedentPregnancyStatusNew]       |    -     |
-|Surgery Date |     InputContent   |    -    | [SurgeryDate] |       -       |    -     |
-{: .grid }
-
-# Coded Race and Ethnicity
-
-| Name of Profile  | Group | change  |  Current Profile   | New Profile  | Comment |
-| ------------- | ----- | ------- | ------------------ | ------------ | ----- | 
-| CodedRaceAndEthnicity |     CodedContent   |    -    | [CodedRaceAndEthnicity] |      [CodedRaceAndEthnicityNew]       |    -     |
-| Input Race and Ethnicity |     InputContent    |    -    | [InputRaceAndEthnicity] |       [InputRaceAndEthnicityNew]       |    -     |
-{: .grid }
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Previous Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-activity-at-time-of-death-vs.html'>ActivityAtTimeOfDeathVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-activity-at-time-of-death-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-administrative-gender-vs.html'>AdministrativeGenderVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-administrative-gender-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-certifier-types-vs.html'>CertifierTypesVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-certifier-types-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-contributory-tobacco-use-vs.html'>ContributoryTobaccoUseVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-contributory-tobacco-use-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-date-of-death-determination-methods-vs.html'>DateOfDeathDeterminationMethodsVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-date-of-death-determination-methods-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-edit-bypass-01-vs.html'>EditBypass01VS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-edit-bypass-01-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-edit-bypass-012-vs.html'>EditBypass012VS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-edit-bypass-012-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-edit-bypass-0124-vs.html'>EditBypass0124VS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-edit-bypass-0124-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-filing-format-vs.html'>FilingFormatVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-filing-format-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-icd10-causes-of-death-vs.html'>ICD10CausesOfDeathVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-icd10-causes-of-death-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-intentional-reject-vs.html'>IntentionalRejectVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-intentional-reject-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-manner-of-death-vs.html'>MannerOfDeathVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-manner-of-death-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-marital-status-vs.html'>MaritalStatusVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-marital-status-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-method-of-disposition-vs.html'>MethodOfDispositionVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-method-of-disposition-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-place-of-death-vs.html'>PlaceOfDeathVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-place-of-death-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-place-of-injury-vs.html'>PlaceOfInjuryVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-place-of-injury-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-replace-status-vs.html'>ReplaceStatusVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-replace-status-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-spouse-alive-vs.html'>SpouseAliveVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-spouse-alive-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-system-reject-vs.html'>SystemRejectVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-system-reject-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-transax-conversion-vs.html'>TransaxConversionVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-transax-conversion-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-vrdr-transportation-incident-role-vs.html'>TransportationIncidentRoleVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-transportation-incident-role-vs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/ValueSet-ValueSet-death-pregnancy-status.html'>DeathPregnancyStatusVS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-pregnancy-status-vs.html'>VRDR</a> </td><td>-</td></tr>
+</tbody>
+</table>
 
 
-{% include markdown-link-references.md %}
+### STU3 Codesystems
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Previous Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-activity-at-time-of-death-cs.html'>ActivityAtTimeOfDeathCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-activity-at-time-of-death-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-bypass-edit-flag-cs.html'>BypassEditFlagCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-bypass-edit-flag-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-CodeSystem-death-pregnancy-status.html'>DeathPregnancyStatusCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-pregnancy-status-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-date-of-death-determination-methods-cs.html'>DateOfDeathDeterminationMethodsCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-date-of-death-determination-methods-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-document-section-cs.html'>DocumentSectionCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-document-section-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-filing-format-cs.html'>FilingFormatCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-filing-format-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-intentional-reject-cs.html'>IntentionalRejectCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-intentional-reject-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-organization-type-cs.html'>OrganizationTypeCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-organization-type-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-location-type-cs.html'>LocationTypeCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-location-type-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-replace-status-cs.html'>ReplaceStatusCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-replace-status-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-system-reject-cs.html'>SystemRejectCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-system-reject-cs.html'>VRDR</a> </td><td>-</td></tr>
+<tr><td> <a href='https://build.fhir.org/ig/nightingaleproject/vital_records_sandbox_ig/CodeSystem-vrdr-transax-conversion-cs.html'>TransaxConversionCS</a> </td><td><a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-transax-conversion-cs.html'>VRDR</a> </td><td>-</td></tr>
+</tbody>
+</table>
+
+
+### Removed Profiles
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Current Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-decedent-usual-work.html'>DecedentUsualWork</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-Observation-usual-work-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-emerging-issues.html'>EmergingIssues</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-Observation-emerging-issues-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-input-race-and-ethnicity.html'>InputRaceAndEthnicity</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-input-race-and-ethnicity-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-vrdr-coded-race-and-ethnicity.html'>CodedRaceAndEthnicity</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-coded-race-and-ethnicity-vr.html'>VRCL</a> </td><td>-</td></tr>
+</tbody>
+</table>
+
+
+### Removed Extensions
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Current Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-BypassEditFlag.html'>BypassEditFlag</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-BypassEditFlag.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-CityCode.html'>CityCode</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-CityCode.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-Date-Day.html'>DateDay</a> </td><td>Removed</td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-Date-Month.html'>DateMonth</a> </td><td>Removed</td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-Date-Time.html'>DateTime</a> </td><td>Removed</td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-Date-Year.html'>DateYear</a> </td><td>Removed</td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-DistrictCode.html'>DistrictCode</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-DistrictCode.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-PartialDate.html'>PartialDate</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-ExtensionPartialDateVitalRecords.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-PartialDateTime.html'>PartialDateTime</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-ExtensionPartialDateTimeVitalRecords.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-PostDirectional.html'>PostDirectional</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-PostDirectional.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-PreDirectional.html'>PreDirectional</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-PreDirectional.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-StreetDesignator.html'>StreetDesignator</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-StreetDesignator.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-StreetName.html'>StreetName</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-StreetName.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-StreetNumber.html'>StreetNumber</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-StreetNumber.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-UnitOrAptNumber.html'>UnitOrAptNumber</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-UnitOrAptNumber.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/StructureDefinition-WithinCityLimitsIndicator.html'>WithinCityLimitsIndicator</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-Extension-within-city-limits-indicator-vr.html'>VRCL</a> </td><td>-</td></tr>
+</tbody>
+</table>
+
+
+### Removed Valuesets
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Current Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-birthplace-country-vs.html'>BirthplaceCountryVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-birthplace-country-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-canada-provinces-vs.html'>CanadaProvincesVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-CodeSystem-canadian-provinces-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-edit-bypass-01234-vs.html'>EditBypass01234VS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-valueset-edit-bypass-01234-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-education-level-vs.html'>EducationLevelVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-education-level-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-hispanic-no-unknown-vs.html'>HispanicNoUnknownVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-hispanic-no-unknown-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-hispanic-origin-vs.html'>HispanicOriginVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-hispanic-origin-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-jurisdiction-vs.html'>JurisdictionVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-jurisdiction-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-race-code-vs.html'>RaceCodeVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-race-code-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-race-missing-value-reason-vs.html'>RaceMissingValueReasonVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-race-missing-value-reason-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-race-recode-40-vs.html'>RaceRecode40VS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-race-recode-40-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-residence-country-vs.html'>ResidenceCountryVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-residence-country-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-states-territories-provinces-vs.html'>StatesTerritoriesAndProvincesVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-states-territories-provinces-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-usstates-territories-vs.html'>USStatesAndTerritoriesVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-usstates-territories-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-units-of-age-vs.html'>UnitsOfAgeVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-units-of-age-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-yes-no-unknown-vs.html'>YesNoUnknownVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-yes-no-unknown-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/ValueSet-vrdr-yes-no-unknown-not-applicable-vs.html'>YesNoUnknownNotApplicableVS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/ValueSet-ValueSet-yes-no-unknown-not-applicable-vr.html'>VRCL</a> </td><td>-</td></tr>
+</tbody>
+</table>
+
+
+### Removed Codesystems
+
+<table align='left' border='1' class='style1' cellpadding='1' cellspacing='1'>
+<tbody>
+<tr>
+<td style='background-color:#98c1d9; text-align: center; width: 37%;'><b>Name</b></td>
+<td style='background-color:#98c1d9; text-align: center; width: 20%;'><b>Current Version/Location</b></td>
+<td style='background-color:#98c1d9; text-align: center;'><b>Comments/Updates</b></td>
+</tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-canadian-provinces-cs.html'>CanadianProvincesCS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-CodeSystem-canadian-provinces-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-country-code-cs.html'>CountryCodeCS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-CodeSystem-country-code-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-hispanic-origin-cs.html'>HispanicOriginCS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-CodeSystem-hispanic-origin-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-jurisdictions-cs.html'>JurisdictionsCS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-CodeSystem-jurisdictions-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-missing-value-reason-cs.html'>MissingValueReasonCS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-CodeSystem-missing-value-reason-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-race-code-cs.html'>RaceCodeCS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-CodeSystem-missing-value-reason-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-race-recode-40-cs.html'>RaceRecode40CS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-CodeSystem-race-recode-40-vr.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-component-cs.html'>ComponentCS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-codesystem-vr-component.html'>VRCL</a> </td><td>-</td></tr>
+<tr><td> <a href='http://hl7.org/fhir/us/vrdr/STU2.2/CodeSystem-vrdr-observations-cs.html'>ObservationsCS</a> </td><td><a href='http://build.fhir.org/ig/HL7/vr-common-library/CodeSystem-CodeSystem-local-observation-codes-vr.html'>VRCL</a> </td><td>-</td></tr>
+</tbody>
+</table>
+


### PR DESCRIPTION
### Summary

Updated content transitions for MDI and VRDR to match BFDR/VRCL format and include some more recent transitions

**Note:** 
- local component & local observation still have a copy that exists in the VRDR sandbox. The content transition page references the VRCL version
- there will be a broken link for  DocumentReference - MDI Report until Tricia's PR is merged


**TODO:**
- add comments on substantive changes
- order content more thematically (e.g., put all bundles together)